### PR TITLE
Hugues' local changes

### DIFF
--- a/helpers/Helper_InvariantMass.h
+++ b/helpers/Helper_InvariantMass.h
@@ -47,7 +47,56 @@ bool PassDiJet140_70_Mjj900(ROOT::VecOps::RVec<float>pt, ROOT::VecOps::RVec<floa
   return false;
 }
 
+bool PassDiJet80_40_Mjj500(ROOT::VecOps::RVec<float>pt, ROOT::VecOps::RVec<float>eta, ROOT::VecOps::RVec<float>phi){
 
+  for(unsigned int i = 0; i<pt.size(); i++){
+    if(pt[i]<80)continue;
+    for(unsigned int j = 0; j<pt.size(); j++){
+      if(eta[i]*eta[j]>0) continue;
+      if(pt[j]<40)continue;
+      TLorentzVector jet1, jet2;
+      jet1.SetPtEtaPhiM(pt[i], eta[i], phi[i], 0.);
+      jet2.SetPtEtaPhiM(pt[j], eta[j], phi[j], 0.);
+      float mass = (jet1+jet2).Mag();
+      if(mass>500) return true;
+    }
+  }
+  return false;
+}
+
+bool PassDiJet80_40_Mjj500_HF(ROOT::VecOps::RVec<float>pt, ROOT::VecOps::RVec<float>eta, ROOT::VecOps::RVec<float>phi){
+
+  for(unsigned int i = 0; i<pt.size(); i++){
+    if(pt[i]<80)continue;
+    for(unsigned int j = 0; j<pt.size(); j++){
+      if(eta[i]*eta[j]>0) continue;
+      if(pt[j]<40)continue;
+      TLorentzVector jet1, jet2;
+      jet1.SetPtEtaPhiM(pt[i], eta[i], phi[i], 0.);
+      jet2.SetPtEtaPhiM(pt[j], eta[j], phi[j], 0.);
+      float mass = (jet1+jet2).Mag();
+      if((mass>500) && (abs(eta[i]) > 3) && (abs(eta[j]) > 3)) return true;
+    }
+  }
+  return false;
+}
+
+bool PassDiJet80_40_Mjj500_central(ROOT::VecOps::RVec<float>pt, ROOT::VecOps::RVec<float>eta, ROOT::VecOps::RVec<float>phi){
+
+  for(unsigned int i = 0; i<pt.size(); i++){
+    if(pt[i]<80)continue;
+    for(unsigned int j = 0; j<pt.size(); j++){
+      if(eta[i]*eta[j]>0) continue;
+      if(pt[j]<40)continue;
+      TLorentzVector jet1, jet2;
+      jet1.SetPtEtaPhiM(pt[i], eta[i], phi[i], 0.);
+      jet2.SetPtEtaPhiM(pt[j], eta[j], phi[j], 0.);
+      float mass = (jet1+jet2).Mag();
+      if((mass>500) && (abs(eta[i]) < 3) && (abs(eta[j]) < 3)) return true;
+    }
+  }
+  return false;
+}
 
 vector<float> HighestMjj(ROOT::VecOps::RVec<float>pt, ROOT::VecOps::RVec<float>eta, ROOT::VecOps::RVec<float>phi){
 

--- a/helpers/bins.py
+++ b/helpers/bins.py
@@ -6,6 +6,10 @@ muEtaBins = [0., 0.83, 1.24, 2.4]
 
 
 ht_bins = array('f', [ i*10 for i in range(50) ] + [ 500+ i*20 for i in range(25) ] + [1000 + i*50 for i in range(10)] +[1500,1600,1700,1800,2000,2500,3000])
-leptonpt_bins = array('f',[ i for i in range(50) ] + [ 50+2*i for i in range(10) ] + [ 70+3*i for i in range(10) ] + [100+10*i for i in range(10) ] + [200, 250, 300, 400, 500])
+#leptonpt_bins = array('f',[ i for i in range(50) ] + [ 50+2*i for i in range(10) ] + [ 70+3*i for i in range(10) ] + [100+10*i for i in range(10) ] + [200, 250, 300, 400, 500])
 jetmetpt_bins = array('f',[ i*5 for i in range(50) ] +  [250+10*i for i in range(25) ]  + [500+20*i for i in range(10) ] + [700, 800, 900, 1000, 1200, 1500, 2000 ])
 
+# Finer binning:
+leptonpt_bins = array('f',[i * .2 for i in range(15 * 5)] + [ 15 + i * .5 for i in range(5 * 2)] + [20 + i for i in range(30)] + [ 50+2*i for i in range(10) ] + [ 70+3*i for i in range(10) ] + [100+10*i for i in range(10) ] + [200, 250, 300, 400, 500])
+
+coarse_leptonpt_bins = array('f',[ i for i in range(50) ] + [ 50+2*i for i in range(10) ] + [ 70+3*i for i in range(10) ] + [100+10*i for i in range(10) ] + [200, 250, 300, 400, 500])

--- a/helpers/helper.py
+++ b/helpers/helper.py
@@ -125,11 +125,14 @@ EventsToPrint++;
 return true;
 '''
 
-
-
-
-
-
+highEnergyJet = '''
+for( unsigned int i = 0; i < (_jetPt).size(); i++){
+    if(_jetPt[i] * cosh(_jetEta[i]) > 6000){
+        return false;
+    }
+}
+return true;
+'''
 def SinglePhotonSelection(df):
     '''
     Select events with exactly one photon with pT>20 GeV.
@@ -166,6 +169,9 @@ def MuonJet_MuonSelection(df):
     df = df.Filter('Sum(goodmuonPt25)>=1','>=1 muon with p_{T}>25 GeV')
     df = df.Define('badmuonPt10','_lPt>10&&abs(_lpdgId)==13&&_lPassTightID==0')
     df = df.Filter('Sum(badmuonPt10)==0','No bad quality muon')
+
+    # reject events containing a jet with energy > 6000 GeV
+#    df = df.Filter(highEnergyJet, 'No high energy jet')
     return df
     
     
@@ -184,6 +190,8 @@ def ZEE_EleSelection(df):
     df = df.Define('probe_Pt','_lPt[isProbe]')
     df = df.Define('probe_Eta','_lEta[isProbe]')
     df = df.Define('probe_Phi','_lPhi[isProbe]')
+
+    #df = df.Define('probe_Charge', '_l
     
     return df
 
@@ -209,7 +217,7 @@ def ZMuMu_MuSelection(df):
 
     
 
-def makehistosforturnons_inprobeetaranges(df, histos, etavarname, phivarname, ptvarname, responsevarname, etabins, l1varname, l1thresholds, prefix, binning, l1thresholdforeffvsrunnb, offlinethresholdforeffvsrunnb):
+def makehistosforturnons_inprobeetaranges(df, histos, etavarname, phivarname, ptvarname, responsevarname, etabins, l1varname, l1thresholds, prefix, binning, l1thresholdforeffvsrunnb, offlinethresholdforeffvsrunnb, suffix = ''):
     '''Make histos for turnons vs pt (1D histos for numerator and denominator) in ranges of eta
     Also look at response vs run number (2D histo) '''
     for i in range(len(etabins)-1):
@@ -222,9 +230,9 @@ def makehistosforturnons_inprobeetaranges(df, histos, etavarname, phivarname, pt
         df_etarange = df_etarange.Define('runnb',"return ROOT::VecOps::RVec<int>(response.size(), _runNb);")
 
         #Response vs pt and vs runnb (2d)
-        histos[prefix+str_bineta] = df_etarange.Histo1D(ROOT.RDF.TH1DModel('h_{}_{}'.format(prefix, str_bineta), '', len(binning)-1, binning), 'denominator_pt')
-        histos[prefix+str_bineta+'_ResponseVsPt'] = df_etarange.Histo2D(ROOT.RDF.TH2DModel('h_ResponseVsPt_{}_{}'.format(prefix, str_bineta), '', 200, 0, 200, 100, 0, 2), 'denominator_pt', 'response')
-        histos[prefix+str_bineta+'_ResponseVsRunNb'] = df_etarange.Histo2D(ROOT.RDF.TH2DModel('h_ResponseVsRunNb_{}_{}'.format(prefix, str_bineta), '', len(runnb_bins)-1, runnb_bins, len(response_bins)-1, response_bins), 'runnb', 'response')
+        histos[prefix+str_bineta+suffix] = df_etarange.Histo1D(ROOT.RDF.TH1DModel('h_{}_{}'.format(prefix, str_bineta)+suffix, '', len(binning)-1, binning), 'denominator_pt')
+        histos[prefix+str_bineta+'_ResponseVsPt'+suffix] = df_etarange.Histo2D(ROOT.RDF.TH2DModel('h_ResponseVsPt_{}_{}'.format(prefix, str_bineta)+suffix, '', 200, 0, 200, 100, 0, 2), 'denominator_pt', 'response')
+        histos[prefix+str_bineta+'_ResponseVsRunNb'+suffix] = df_etarange.Histo2D(ROOT.RDF.TH2DModel('h_ResponseVsRunNb_{}_{}'.format(prefix, str_bineta)+suffix, '', len(runnb_bins)-1, runnb_bins, len(response_bins)-1, response_bins), 'runnb', 'response')
 
         if i ==1 and prefix == 'EGNonIso_plots':
             df_etarange = df_etarange.Filter(stringToPrint)
@@ -237,21 +245,21 @@ def makehistosforturnons_inprobeetaranges(df, histos, etavarname, phivarname, pt
         df_etarange = df_etarange.Define('inplateaupassL1','inplateau && {}>={}'.format(l1varname,l1thresholdforeffvsrunnb))
         df_etarange = df_etarange.Define('N_inplateaupassL1','Sum(inplateaupassL1)')
         df_etarange = df_etarange.Define('runnb_inplateaupassL1',"return ROOT::VecOps::RVec<int>(N_inplateaupassL1, _runNb);")
-        histos[prefix+"_plateaueffvsrunnb_numerator_"+str_bineta] = df_etarange.Histo1D(ROOT.RDF.TH1DModel('h_PlateauEffVsRunNb_Numerator_{}_{}'.format(prefix, str_bineta), '', len(runnb_bins)-1, runnb_bins),'runnb_inplateaupassL1')
-        histos[prefix+"_plateaueffvsrunnb_denominator_"+str_bineta] = df_etarange.Histo1D(ROOT.RDF.TH1DModel('h_PlateauEffVsRunNb_Denominator_{}_{}'.format(prefix, str_bineta), '', len(runnb_bins)-1, runnb_bins),'runnb_inplateau')
+        histos[prefix+"_plateaueffvsrunnb_numerator_"+str_bineta+suffix] = df_etarange.Histo1D(ROOT.RDF.TH1DModel('h_PlateauEffVsRunNb_Numerator_{}_{}'.format(prefix, str_bineta)+suffix, '', len(runnb_bins)-1, runnb_bins),'runnb_inplateaupassL1')
+        histos[prefix+"_plateaueffvsrunnb_denominator_"+str_bineta+suffix] = df_etarange.Histo1D(ROOT.RDF.TH1DModel('h_PlateauEffVsRunNb_Denominator_{}_{}'.format(prefix, str_bineta)+suffix, '', len(runnb_bins)-1, runnb_bins),'runnb_inplateau')
 
         for ipt in l1thresholds:
             str_binetapt = "eta{}to{}_l1thrgeq{}".format(etabins[i], etabins[i+1],ipt).replace(".","p")
             df_loc = df_etarange.Define('passL1Cond','{}>={}'.format(l1varname, ipt))
             df_loc = df_loc.Define('numerator_pt',ptvarname+'[inEtaRange&&passL1Cond]')
-            histos[prefix+str_binetapt] = df_loc.Histo1D(ROOT.RDF.TH1DModel('h_{}_{}'.format(prefix, str_binetapt), '', len(binning)-1, binning), 'numerator_pt')
+            histos[prefix+str_binetapt+suffix] = df_loc.Histo1D(ROOT.RDF.TH1DModel('h_{}_{}'.format(prefix, str_binetapt)+suffix, '', len(binning)-1, binning), 'numerator_pt')
 
 
     return df
 
     
 
-def ZEE_Plots(df):
+def ZEE_Plots(df, suffix = ''):
     histos = {}
     
     label = ['EGNonIso','EGLooseIso', 'EGTightIso']
@@ -260,44 +268,65 @@ def ZEE_Plots(df):
         
         if i ==0:
             df_eg[i] = df.Define('probe_idxL1jet','FindL1ObjIdx(_L1eg_eta, _L1eg_phi, probe_Eta, probe_Phi)')
+            df_eg[i] = df_eg[i].Define('probe_idxL1jet_Bx0','FindL1ObjIdx_setBx(_L1eg_eta, _L1eg_phi, _L1eg_bx, probe_Eta, probe_Phi, 0)')
+            df_eg[i] = df_eg[i].Define('probe_idxL1jet_Bxmin1','FindL1ObjIdx_setBx(_L1eg_eta, _L1eg_phi, _L1eg_bx, probe_Eta, probe_Phi, -1)')
+            df_eg[i] = df_eg[i].Define('probe_idxL1jet_Bxplus1','FindL1ObjIdx_setBx(_L1eg_eta, _L1eg_phi, _L1eg_bx, probe_Eta, probe_Phi, 1)')
         if i ==1:
             df_eg[i] = df.Define('probe_idxL1jet','FindL1ObjIdx(_L1eg_eta, _L1eg_phi, probe_Eta, probe_Phi, _L1eg_iso, 2)')
+            df_eg[i] = df_eg[i].Define('probe_idxL1jet_Bx0','FindL1ObjIdx_setBx(_L1eg_eta, _L1eg_phi, _L1eg_bx, probe_Eta, probe_Phi, 0, _L1eg_iso, 2)')
+            df_eg[i] = df_eg[i].Define('probe_idxL1jet_Bxmin1','FindL1ObjIdx_setBx(_L1eg_eta, _L1eg_phi, _L1eg_bx, probe_Eta, probe_Phi, -1, _L1eg_iso, 2)')
+            df_eg[i] = df_eg[i].Define('probe_idxL1jet_Bxplus1','FindL1ObjIdx_setBx(_L1eg_eta, _L1eg_phi, _L1eg_bx, probe_Eta, probe_Phi, 1, _L1eg_iso, 2)')
         if i ==2:
             df_eg[i] = df.Define('probe_idxL1jet','FindL1ObjIdx(_L1eg_eta, _L1eg_phi, probe_Eta, probe_Phi, _L1eg_iso, 3)')
+            df_eg[i] = df_eg[i].Define('probe_idxL1jet_Bx0','FindL1ObjIdx_setBx(_L1eg_eta, _L1eg_phi, _L1eg_bx, probe_Eta, probe_Phi, 0, _L1eg_iso, 3)')
+            df_eg[i] = df_eg[i].Define('probe_idxL1jet_Bxmin1','FindL1ObjIdx_setBx(_L1eg_eta, _L1eg_phi, _L1eg_bx, probe_Eta, probe_Phi, -1, _L1eg_iso, 3)')
+            df_eg[i] = df_eg[i].Define('probe_idxL1jet_Bxplus1','FindL1ObjIdx_setBx(_L1eg_eta, _L1eg_phi, _L1eg_bx, probe_Eta, probe_Phi, 1, _L1eg_iso, 3)')
 
         df_eg[i] = df_eg[i].Define('probe_L1Pt','GetVal(probe_idxL1jet, _L1eg_pt)')
         df_eg[i] = df_eg[i].Define('probe_L1Bx','GetVal(probe_idxL1jet, _L1eg_bx)')
         df_eg[i] = df_eg[i].Define('probe_L1PtoverRecoPt','probe_L1Pt/probe_Pt')
+
+        df_eg[i] = df_eg[i].Define('probe_L1Pt_Bx0', 'GetVal(probe_idxL1jet_Bx0, _L1eg_pt)')
+        df_eg[i] = df_eg[i].Define('probe_L1Pt_Bxmin1', 'GetVal(probe_idxL1jet_Bxmin1, _L1eg_pt)')
+        df_eg[i] = df_eg[i].Define('probe_L1Pt_Bxplus1', 'GetVal(probe_idxL1jet_Bxplus1, _L1eg_pt)')
+
+        pt_binning = leptonpt_bins
+        if suffix != '':
+            pt_binning = coarse_leptonpt_bins
         
-        df_eg[i] = makehistosforturnons_inprobeetaranges(df_eg[i], histos, etavarname='probe_Eta', phivarname='probe_Phi', ptvarname='probe_Pt', responsevarname='probe_L1PtoverRecoPt', etabins=egEtaBins, l1varname='probe_L1Pt', l1thresholds=[5,10,15,20,25,30,36,37], prefix=label[i]+"_plots", binning=leptonpt_bins, l1thresholdforeffvsrunnb = 30, offlinethresholdforeffvsrunnb = 35 )
+        df_eg[i] = makehistosforturnons_inprobeetaranges(df_eg[i], histos, etavarname='probe_Eta', phivarname='probe_Phi', ptvarname='probe_Pt', responsevarname='probe_L1PtoverRecoPt', etabins=egEtaBins, l1varname='probe_L1Pt', l1thresholds=[5,10,15,20,25,30,36,37], prefix=label[i]+"_plots", binning=pt_binning, l1thresholdforeffvsrunnb = 30, offlinethresholdforeffvsrunnb = 35, suffix = suffix)
         
         
         df_eg[i] = df_eg[i].Define('probePt30_Eta','probe_Eta[probe_Pt>30]')
         df_eg[i] = df_eg[i].Define('probePt30_Phi','probe_Phi[probe_Pt>30]')
         df_eg[i] = df_eg[i].Define('probePt30PassL1EG25_Eta','probe_Eta[probe_Pt>30&&probe_L1Pt>25]')
         df_eg[i] = df_eg[i].Define('probePt30PassL1EG25_Phi','probe_Phi[probe_Pt>30&&probe_L1Pt>25]')
-        histos['h_EG25_EtaPhi_Numerator'+label[i]] = df_eg[i].Histo2D(ROOT.RDF.TH2DModel('h_EG25_EtaPhi_Numerator', '', 100, -5,5, 100, -3.1416, 3.1416), 'probePt30PassL1EG25_Eta', 'probePt30PassL1EG25_Phi')
-        histos['h_EG25_EtaPhi_Denominator'+label[i]] = df_eg[i].Histo2D(ROOT.RDF.TH2DModel('h_EG25_EtaPhi_Denominator', '', 100, -5,5, 100, -3.1416, 3.1416), 'probePt30_Eta', 'probePt30_Phi')
+        histos['h_EG25_EtaPhi_Numerator'+label[i]+suffix] = df_eg[i].Histo2D(ROOT.RDF.TH2DModel('h_EG25_EtaPhi_Numerator'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probePt30PassL1EG25_Eta', 'probePt30PassL1EG25_Phi')
+        histos['h_EG25_EtaPhi_Denominator'+label[i]+suffix] = df_eg[i].Histo2D(ROOT.RDF.TH2DModel('h_EG25_EtaPhi_Denominator'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probePt30_Eta', 'probePt30_Phi')
 
         
         if i ==0:
-            df_eg[i] = df_eg[i].Define('probeL1EG15to26Bxmin1_Eta','probe_Eta[probe_Pt>12&&probe_Pt<23&&probe_L1Pt>15&&probe_L1Pt<=26&&probe_L1Bx==-1]')
-            df_eg[i] = df_eg[i].Define('probeL1EG15to26Bxmin1_Phi','probe_Phi[probe_Pt>12&&probe_Pt<23&&probe_L1Pt>15&&probe_L1Pt<=26&&probe_L1Bx==-1]')
-            df_eg[i] = df_eg[i].Define('probeL1EG15to26Bx0_Eta','probe_Eta[probe_Pt>12&&probe_Pt<23&&probe_L1Pt>15&&probe_L1Pt<=26&&probe_L1Bx==0]')
-            df_eg[i] = df_eg[i].Define('probeL1EG15to26Bx0_Phi','probe_Phi[probe_Pt>12&&probe_Pt<23&&probe_L1Pt>15&&probe_L1Pt<=26&&probe_L1Bx==0]')
-            df_eg[i] = df_eg[i].Define('probeL1EG15to26Bxplus1_Eta','probe_Eta[probe_Pt>12&&probe_Pt<23&&probe_L1Pt>15&&probe_L1Pt<=26&&probe_L1Bx==1]')
-            df_eg[i] = df_eg[i].Define('probeL1EG15to26Bxplus1_Phi','probe_Phi[probe_Pt>12&&probe_Pt<23&&probe_L1Pt>15&&probe_L1Pt<=26&&probe_L1Bx==1]')
+            df_eg[i] = df_eg[i].Define('probeL1EG15to26Bxmin1_Eta', 'probe_Eta[probe_Pt>12&&probe_Pt<23&&probe_L1Pt_Bxmin1>15&&probe_L1Pt_Bxmin1<=26&&probe_L1Bx==-1]')
+            df_eg[i] = df_eg[i].Define('probeL1EG15to26Bxmin1_Phi', 'probe_Phi[probe_Pt>12&&probe_Pt<23&&probe_L1Pt_Bxmin1>15&&probe_L1Pt_Bxmin1<=26&&probe_L1Bx==-1]')
+            df_eg[i] = df_eg[i].Define('probeL1EG15to26Bx0_Eta', 'probe_Eta[probe_Pt>12&&probe_Pt<23&&probe_L1Pt_Bx0>15&&probe_L1Pt_Bx0<=26&&probe_L1Bx==0]')
+            df_eg[i] = df_eg[i].Define('probeL1EG15to26Bx0_Phi', 'probe_Phi[probe_Pt>12&&probe_Pt<23&&probe_L1Pt_Bx0>15&&probe_L1Pt_Bx0<=26&&probe_L1Bx==0]')
+            df_eg[i] = df_eg[i].Define('probeL1EG15to26Bxplus1_Eta', 'probe_Eta[probe_Pt>12&&probe_Pt<23&&probe_L1Pt_Bxplus1>15&&probe_L1Pt_Bxplus1<=26&&probe_L1Bx==1]')
+            df_eg[i] = df_eg[i].Define('probeL1EG15to26Bxplus1_Phi', 'probe_Phi[probe_Pt>12&&probe_Pt<23&&probe_L1Pt_Bxplus1>15&&probe_L1Pt_Bxplus1<=26&&probe_L1Bx==1]')
             
             
-            histos['L1EG15to26_bxmin1_etaphi'] = df_eg[i].Histo2D(ROOT.RDF.TH2DModel('L1EG15to26_bxmin1_etaphi', '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1EG15to26Bxmin1_Eta', 'probeL1EG15to26Bxmin1_Phi')
-            histos['L1EG15to26_bx0_etaphi'] = df_eg[i].Histo2D(ROOT.RDF.TH2DModel('L1EG15to26_bx0_etaphi', '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1EG15to26Bx0_Eta', 'probeL1EG15to26Bx0_Phi')
-            histos['L1EG15to26_bxplus1_etaphi'] = df_eg[i].Histo2D(ROOT.RDF.TH2DModel('L1EG15to26_bxplus1_etaphi', '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1EG15to26Bxplus1_Eta', 'probeL1EG15to26Bxplus1_Phi')
+            histos['L1EG15to26_bxmin1_etaphi'+suffix] = df_eg[i].Histo2D(ROOT.RDF.TH2DModel('L1EG15to26_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1EG15to26Bxmin1_Eta', 'probeL1EG15to26Bxmin1_Phi')
+            histos['L1EG15to26_bx0_etaphi'+suffix] = df_eg[i].Histo2D(ROOT.RDF.TH2DModel('L1EG15to26_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1EG15to26Bx0_Eta', 'probeL1EG15to26Bx0_Phi')
+            histos['L1EG15to26_bxplus1_etaphi'+suffix] = df_eg[i].Histo2D(ROOT.RDF.TH2DModel('L1EG15to26_bxplus1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1EG15to26Bxplus1_Eta', 'probeL1EG15to26Bxplus1_Phi')
+
+            histos['L1EG15to26_bxmin1_eta'+suffix] = df_eg[i].Histo1D(ROOT.RDF.TH1DModel('L1EG15to26_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1EG15to26Bxmin1_Eta')
+            histos['L1EG15to26_bx0_eta'+suffix] = df_eg[i].Histo1D(ROOT.RDF.TH1DModel('L1EG15to26_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1EG15to26Bx0_Eta')
+            histos['L1EG15to26_bxplus1_eta'+suffix] = df_eg[i].Histo1D(ROOT.RDF.TH1DModel('L1EG15to26_bxplus1_eta'+suffix, '', 100, -5, 5), 'probeL1EG15to26Bxplus1_Eta')
 
     return df, histos
     
 
 
-def ZMuMu_Plots(df):
+def ZMuMu_Plots(df, suffix = ''):
                                                                                           
     histos = {}
     label = ['AllQual', 'Qual8', 'Qual12']
@@ -305,21 +334,45 @@ def ZMuMu_Plots(df):
     
     for i in range(3):
         if i == 0:
-            df_mu[i] = df.Define('probe_idxL1jet','FindL1ObjIdx(_L1mu_eta, _L1mu_phi, probe_Eta, probe_Phi)')
+            df_mu[i] = df.Define('probe_idxL1jet','FindL1ObjIdx(_L1mu_eta, _L1mu_phi, probe_Eta, probe_Phi, probe_Pt, _L1mu_charge)')
+            df_mu[i] = df_mu[i].Define('probe_idxL1jet_Bx0','FindL1ObjIdx_setBx(_L1mu_eta, _L1mu_phi, _L1mu_bx, probe_Eta, probe_Phi, probe_Pt, _L1mu_charge, 0)')
+            df_mu[i] = df_mu[i].Define('probe_idxL1jet_Bxmin1','FindL1ObjIdx_setBx(_L1mu_eta, _L1mu_phi, _L1mu_bx, probe_Eta, probe_Phi, probe_Pt, _L1mu_charge, -1)')
+            df_mu[i] = df_mu[i].Define('probe_idxL1jet_Bxplus1','FindL1ObjIdx_setBx(_L1mu_eta, _L1mu_phi, _L1mu_bx, probe_Eta, probe_Phi, probe_Pt, _L1mu_charge, 1)')
         if i == 1:
-            df_mu[i] = df.Define('probe_idxL1jet','FindL1ObjIdx(_L1mu_eta, _L1mu_phi, probe_Eta, probe_Phi, _L1mu_Qual, 8)')
+            df_mu[i] = df.Define('probe_idxL1jet','FindL1ObjIdx(_L1mu_eta, _L1mu_phi, probe_Eta, probe_Phi, probe_Pt, _L1mu_charge, _L1mu_Qual, 8)')
+            df_mu[i] = df_mu[i].Define('probe_idxL1jet_Bx0','FindL1ObjIdx_setBx(_L1mu_eta, _L1mu_phi, _L1mu_bx, probe_Eta, probe_Phi, probe_Pt, _L1mu_charge, 0, _L1mu_Qual, 8)')
+            df_mu[i] = df_mu[i].Define('probe_idxL1jet_Bxmin1','FindL1ObjIdx_setBx(_L1mu_eta, _L1mu_phi, _L1mu_bx, probe_Eta, probe_Phi, probe_Pt, _L1mu_charge, -1, _L1mu_Qual, 8)')
+            df_mu[i] = df_mu[i].Define('probe_idxL1jet_Bxplus1','FindL1ObjIdx_setBx(_L1mu_eta, _L1mu_phi, _L1mu_bx, probe_Eta, probe_Phi, probe_Pt, _L1mu_charge, 1, _L1mu_Qual, 8)')
         if i == 2:
-            df_mu[i] = df.Define('probe_idxL1jet','FindL1ObjIdx(_L1mu_eta, _L1mu_phi, probe_Eta, probe_Phi, _L1mu_Qual, 12)')
+            df_mu[i] = df.Define('probe_idxL1jet','FindL1ObjIdx(_L1mu_eta, _L1mu_phi, probe_Eta, probe_Phi, probe_Pt, _L1mu_charge, _L1mu_Qual, 12)')
+            df_mu[i] = df_mu[i].Define('probe_idxL1jet_Bx0','FindL1ObjIdx_setBx(_L1mu_eta, _L1mu_phi, _L1mu_bx, probe_Eta, probe_Phi, probe_Pt, _L1mu_charge, 0, _L1mu_Qual, 12)')
+            df_mu[i] = df_mu[i].Define('probe_idxL1jet_Bxmin1','FindL1ObjIdx_setBx(_L1mu_eta, _L1mu_phi, _L1mu_bx, probe_Eta, probe_Phi, probe_Pt, _L1mu_charge, -1, _L1mu_Qual, 12)')
+            df_mu[i] = df_mu[i].Define('probe_idxL1jet_Bxplus1','FindL1ObjIdx_setBx(_L1mu_eta, _L1mu_phi, _L1mu_bx, probe_Eta, probe_Phi, probe_Pt, _L1mu_charge, 1, _L1mu_Qual, 12)')
 
             
 
         df_mu[i] = df_mu[i].Define('probe_L1Pt','GetVal(probe_idxL1jet, _L1mu_pt)')
         df_mu[i] = df_mu[i].Define('probe_L1Bx','GetVal(probe_idxL1jet, _L1mu_bx)')
         df_mu[i] = df_mu[i].Define('probe_L1Qual','GetVal(probe_idxL1jet, _L1mu_Qual)')
+
+        df_mu[i] = df_mu[i].Define('probe_L1Pt_Bx0', 'GetVal(probe_idxL1jet_Bx0, _L1mu_pt)')
+        df_mu[i] = df_mu[i].Define('probe_L1Qual_Bx0', 'GetVal(probe_idxL1jet_Bx0, _L1mu_Qual)')
+
+        df_mu[i] = df_mu[i].Define('probe_L1Pt_Bxmin1', 'GetVal(probe_idxL1jet_Bxmin1, _L1mu_pt)')
+        df_mu[i] = df_mu[i].Define('probe_L1Qual_Bxmin1', 'GetVal(probe_idxL1jet_Bxmin1, _L1mu_Qual)')
+
+        df_mu[i] = df_mu[i].Define('probe_L1Pt_Bxplus1', 'GetVal(probe_idxL1jet_Bxplus1, _L1mu_pt)')
+        df_mu[i] = df_mu[i].Define('probe_L1Qual_Bxplus1', 'GetVal(probe_idxL1jet_Bxplus1, _L1mu_Qual)')
+
         df_mu[i] = df_mu[i].Define('probe_L1PtoverRecoPt','probe_L1Pt/probe_Pt')
         
         
-        df_mu[i] = makehistosforturnons_inprobeetaranges(df_mu[i], histos, etavarname='probe_Eta', phivarname='probe_Phi', ptvarname='probe_Pt', responsevarname='probe_L1PtoverRecoPt', etabins=muEtaBins, l1varname='probe_L1Pt', l1thresholds=[5,10,15,20,22,26],  prefix=label[i]+"_plots" , binning = leptonpt_bins, l1thresholdforeffvsrunnb = 22, offlinethresholdforeffvsrunnb = 27)
+        pt_binning = leptonpt_bins
+        if suffix != '':
+            pt_binning = coarse_leptonpt_bins
+
+
+        df_mu[i] = makehistosforturnons_inprobeetaranges(df_mu[i], histos, etavarname='probe_Eta', phivarname='probe_Phi', ptvarname='probe_Pt', responsevarname='probe_L1PtoverRecoPt', etabins=muEtaBins, l1varname='probe_L1Pt', l1thresholds=[3, 5,10,15,20,22,26],  prefix=label[i]+"_plots" , binning = pt_binning, l1thresholdforeffvsrunnb = 22, offlinethresholdforeffvsrunnb = 27, suffix = suffix)
         
     
         df_mu[i] = df_mu[i].Define('probePt30_Eta','probe_Eta[probe_Pt>30]')
@@ -328,14 +381,8 @@ def ZMuMu_Plots(df):
         df_mu[i] = df_mu[i].Define('probePt30PassL1Mu22_Phi','probe_Phi[probe_Pt>30&&probe_L1Pt>22]')
         df_mu[i] = df_mu[i].Define('probePt30PassL1Mu22_L1Bx','probe_L1Bx[probe_Pt>30&&probe_L1Pt>22]')
 
-
-
-
-
-
-
-        histos['h_Mu22_EtaPhi_Denominator'+label[i]] = df_mu[i].Histo2D(ROOT.RDF.TH2DModel('h_Mu22_EtaPhi_Denominator', '', 100, -5,5, 100, -3.1416, 3.1416), 'probePt30_Eta', 'probePt30_Phi')
-        histos['h_Mu22_EtaPhi_Numerator'+label[i]] = df_mu[i].Histo2D(ROOT.RDF.TH2DModel('h_Mu22_EtaPhi_Numerator', '', 100, -5,5, 100, -3.1416, 3.1416), 'probePt30PassL1Mu22_Eta', 'probePt30PassL1Mu22_Phi')
+        histos['h_Mu22_EtaPhi_Denominator'+label[i]+suffix] = df_mu[i].Histo2D(ROOT.RDF.TH2DModel('h_Mu22_EtaPhi_Denominator'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probePt30_Eta', 'probePt30_Phi')
+        histos['h_Mu22_EtaPhi_Numerator'+label[i]+suffix] = df_mu[i].Histo2D(ROOT.RDF.TH2DModel('h_Mu22_EtaPhi_Numerator'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probePt30PassL1Mu22_Eta', 'probePt30PassL1Mu22_Phi')
         
         
         if i == 2:
@@ -346,9 +393,9 @@ def ZMuMu_Plots(df):
             df_mu[i] = df_mu[i].Define('probeL1Mu10to21Bxplus1_Eta','probe_Eta[probe_Pt>8&&probe_Pt<25&&probe_L1Pt>10&&probe_L1Pt<=21&&probe_L1Bx==1&&probe_L1Qual>=12]')
             df_mu[i] = df_mu[i].Define('probeL1Mu10to21Bxplus1_Phi','probe_Phi[probe_Pt>8&&probe_Pt<25&&probe_L1Pt>10&&probe_L1Pt<=21&&probe_L1Bx==1&&probe_L1Qual>=12]')
                         
-            histos['L1Mu10to21_bxmin1_etaphi'] = df_mu[i].Histo2D(ROOT.RDF.TH2DModel('L1Mu10to21_bxmin1_etaphi', '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu10to21Bxmin1_Eta', 'probeL1Mu10to21Bxmin1_Phi')
-            histos['L1Mu10to21_bx0_etaphi'] = df_mu[i].Histo2D(ROOT.RDF.TH2DModel('L1Mu10to21_bx0_etaphi', '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu10to21Bx0_Eta', 'probeL1Mu10to21Bx0_Phi')
-            histos['L1Mu10to21_bxplus1_etaphi'] = df_mu[i].Histo2D(ROOT.RDF.TH2DModel('L1Mu10to21_bxplus1_etaphi', '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu10to21Bxplus1_Eta', 'probeL1Mu10to21Bxplus1_Phi')
+            histos['L1Mu10to21_bxmin1_etaphi'+suffix] = df_mu[i].Histo2D(ROOT.RDF.TH2DModel('L1Mu10to21_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu10to21Bxmin1_Eta', 'probeL1Mu10to21Bxmin1_Phi')
+            histos['L1Mu10to21_bx0_etaphi'+suffix] = df_mu[i].Histo2D(ROOT.RDF.TH2DModel('L1Mu10to21_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu10to21Bx0_Eta', 'probeL1Mu10to21Bx0_Phi')
+            histos['L1Mu10to21_bxplus1_etaphi'+suffix] = df_mu[i].Histo2D(ROOT.RDF.TH2DModel('L1Mu10to21_bxplus1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu10to21Bxplus1_Eta', 'probeL1Mu10to21Bxplus1_Phi')
             '''
             #L1 prefiring measurement with unprefirable events
             
@@ -389,7 +436,7 @@ def CleanJets(df):
 
 
 
-def EtSum(df):
+def EtSum(df, suffix = ''):
     histos = {}
     #HT=scalar pt sum of all jets with pt>30 and |eta|<2.5 
     df = df.Define('iscentraljet','cleanJet_Pt>30&&abs(cleanJet_Eta)<2.5')
@@ -402,34 +449,69 @@ def EtSum(df):
     df = df.Define('metnomu_y','_met*sin(_met_phi)+muons_py')
     df = df.Define('MetNoMu','sqrt(metnomu_x*metnomu_x+metnomu_y*metnomu_y)')
     df = df.Define('L1_ETMHF80','passL1_Initial_bx0[419]')
+    df = df.Define('L1_ETMHF90','passL1_Initial_bx0[420]')
     df = df.Define('L1_ETMHF100','passL1_Initial_bx0[421]')
     df = df.Define('L1_ETMHF110','passL1_Initial_bx0[422]')
 
-    histos['h_MetNoMu_Denominator'] = df.Histo1D(ROOT.RDF.TH1DModel('h_MetNoMu_Denominator', '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu') 
+    # Dijet selections
+    df = df.Define('hastwocleanjets', 'PassDiJet80_40_Mjj500(cleanJet_Pt, cleanJet_Eta, cleanJet_Phi)')
+    df = df.Define('vbf_selection', 'PassDiJet140_70_Mjj900(cleanJet_Pt, cleanJet_Eta, cleanJet_Phi)')
+    df = df.Define('hastwocentraljets', 'PassDiJet80_40_Mjj500_central(cleanJet_Pt, cleanJet_Eta, cleanJet_Phi)')
+    df = df.Define('hastwoHFjets', 'PassDiJet80_40_Mjj500_HF(cleanJet_Pt, cleanJet_Eta, cleanJet_Phi)')
+
+    histos['h_MetNoMu_Denominator'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel('h_MetNoMu_Denominator'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu') 
     
     dfmetl1 = df.Filter('passL1_Initial_bx0[419]')
-    histos['L1_ETMHF80'] = dfmetl1.Histo1D(ROOT.RDF.TH1DModel('h_MetNoMu_ETMHF80', '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
+    histos['L1_ETMHF80'+suffix] = dfmetl1.Histo1D(ROOT.RDF.TH1DModel('h_MetNoMu_ETMHF80'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
+    dfmetl1 = df.Filter('passL1_Initial_bx0[420]')
+    histos['L1_ETMHF90'+suffix] = dfmetl1.Histo1D(ROOT.RDF.TH1DModel('h_MetNoMu_ETMHF90'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
     dfmetl1 = df.Filter('passL1_Initial_bx0[421]')
-    histos['L1_ETMHF100'] = dfmetl1.Histo1D(ROOT.RDF.TH1DModel('h_MetNoMu_ETMHF100', '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
+    histos['L1_ETMHF100'+suffix] = dfmetl1.Histo1D(ROOT.RDF.TH1DModel('h_MetNoMu_ETMHF100'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
     dfmetl1 = df.Filter('passL1_Initial_bx0[422]')
-    histos['L1_ETMHF110'] = dfmetl1.Histo1D(ROOT.RDF.TH1DModel('h_MetNoMu_ETMHF110', '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
+    histos['L1_ETMHF110'+suffix] = dfmetl1.Histo1D(ROOT.RDF.TH1DModel('h_MetNoMu_ETMHF110'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
 
-    histos['HLT_PFMETNoMu120_PFMHTNoMu120_IDTight'] =  df.Filter('HLT_PFMETNoMu120_PFMHTNoMu120_IDTight').Histo1D(ROOT.RDF.TH1DModel('h_HLT_PFMETNoMu120_PFMHTNoMu120_IDTight', '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
-    histos['HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60'] =  df.Filter('HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60').Histo1D(ROOT.RDF.TH1DModel('h_HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60', '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
+    histos['HLT_PFMETNoMu120_PFMHTNoMu120_IDTight'+suffix] =  df.Filter('HLT_PFMETNoMu120_PFMHTNoMu120_IDTight').Histo1D(ROOT.RDF.TH1DModel('h_HLT_PFMETNoMu120_PFMHTNoMu120_IDTight'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
+    histos['HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60'+suffix] =  df.Filter('HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60').Histo1D(ROOT.RDF.TH1DModel('h_HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
     
 
-    histos['h_HT_Denominator'] = df.Filter('_met<50').Histo1D(ROOT.RDF.TH1DModel('h_HT_Denominator', '', len(ht_bins)-1, array('d',ht_bins)), 'HT') 
-    histos['L1_HTT200er'] = df.Filter('passL1_Initial_bx0[400]').Filter('_met<50').Histo1D(ROOT.RDF.TH1DModel('h_HT_L1_HTT200er', '', len(ht_bins)-1, array('d',ht_bins)), 'HT')  
-    histos['L1_HTT280er'] = df.Filter('passL1_Initial_bx0[402]').Filter('_met<50').Histo1D(ROOT.RDF.TH1DModel('h_HT_L1_HTT280er', '', len(ht_bins)-1, array('d',ht_bins)), 'HT')
-    histos['L1_HTT360er'] = df.Filter('passL1_Initial_bx0[404]').Filter('_met<50').Histo1D(ROOT.RDF.TH1DModel('h_HT_L1_HTT360er', '', len(ht_bins)-1, array('d',ht_bins)), 'HT')
-    histos['HLT_PFHT1050'] =  df.Filter('HLT_PFHT1050').Filter('_met<50').Histo1D(ROOT.RDF.TH1DModel('h_HLT_PFHT1050', '', len(ht_bins)-1, array('d',ht_bins)), 'HT')
+    histos['h_HT_Denominator'+suffix] = df.Filter('_met<50').Histo1D(ROOT.RDF.TH1DModel('h_HT_Denominator'+suffix, '', len(ht_bins)-1, array('d',ht_bins)), 'HT') 
+    histos['L1_HTT200er'+suffix] = df.Filter('passL1_Initial_bx0[400]').Filter('_met<50').Histo1D(ROOT.RDF.TH1DModel('h_HT_L1_HTT200er'+suffix, '', len(ht_bins)-1, array('d',ht_bins)), 'HT')  
+    histos['L1_HTT280er'+suffix] = df.Filter('passL1_Initial_bx0[402]').Filter('_met<50').Histo1D(ROOT.RDF.TH1DModel('h_HT_L1_HTT280er'+suffix, '', len(ht_bins)-1, array('d',ht_bins)), 'HT')
+    histos['L1_HTT360er'+suffix] = df.Filter('passL1_Initial_bx0[404]').Filter('_met<50').Histo1D(ROOT.RDF.TH1DModel('h_HT_L1_HTT360er'+suffix, '', len(ht_bins)-1, array('d',ht_bins)), 'HT')
+    histos['HLT_PFHT1050'+suffix] =  df.Filter('HLT_PFHT1050').Filter('_met<50').Histo1D(ROOT.RDF.TH1DModel('h_HLT_PFHT1050'+suffix, '', len(ht_bins)-1, array('d',ht_bins)), 'HT')
+
+    # DiJet selections:
+
+    # DiJet 80 40
+    histos['h_MetNoMu_Denominator_DiJet80_40_Mjj500'+suffix] = df.Filter('hastwocleanjets').Histo1D(ROOT.RDF.TH1DModel('h_MetNoMu_Denominator_DiJet80_40_Mjj500'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu') 
+    histos['HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_DiJet80_40_Mjj500'+suffix] = df.Filter('HLT_PFMETNoMu120_PFMHTNoMu120_IDTight&&hastwocleanjets').Histo1D(ROOT.RDF.TH1DModel('h_HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_DiJet80_40_Mjj500'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
+    histos['HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_DiJet80_40_Mjj500'+suffix] = df.Filter('HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60&&hastwocleanjets').Histo1D(ROOT.RDF.TH1DModel('h_HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_DiJet80_40_Mjj500'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
+
+    # central dijet
+    histos['h_MetNoMu_Denominator_DiJet80_40_Mjj500_central'+suffix] = df.Filter('hastwocentraljets').Histo1D(ROOT.RDF.TH1DModel('h_MetNoMu_Denominator_DiJet80_40_Mjj500_central'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu') 
+    histos['HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_DiJet80_40_Mjj500_central'+suffix] = df.Filter('HLT_PFMETNoMu120_PFMHTNoMu120_IDTight&&hastwocentraljets').Histo1D(ROOT.RDF.TH1DModel('h_HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_DiJet80_40_Mjj500_central'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
+
+    # HF dijets
+    histos['h_MetNoMu_Denominator_DiJet80_40_Mjj500_HF'+suffix] = df.Filter('hastwoHFjets').Histo1D(ROOT.RDF.TH1DModel('h_MetNoMu_Denominator_DiJet80_40_Mjj500_HF'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu') 
+    histos['HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_DiJet80_40_Mjj500_HF'+suffix] = df.Filter('HLT_PFMETNoMu120_PFMHTNoMu120_IDTight&&hastwoHFjets').Histo1D(ROOT.RDF.TH1DModel('h_HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_DiJet80_40_Mjj500_HF'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
+
+    # VBF selection (DiJet 140 70, mjj > 900 GeV) denominator
+    histos['h_MetNoMu_Denominator_DiJet140_70_Mjj900'+suffix] = df.Filter('vbf_selection').Histo1D(ROOT.RDF.TH1DModel('h_MetNoMu_Denominator_DiJet140_70_Mjj900'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu') 
+
+    # Normal (MET only) trigger
+    histos['HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_DiJet140_70_Mjj900'+suffix] = df.Filter('HLT_PFMETNoMu120_PFMHTNoMu120_IDTight&&vbf_selection').Histo1D(ROOT.RDF.TH1DModel('h_HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_DiJet140_70_Mjj900'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
+
+    # VBF (Met + jet) trigger
+    histos['HLT_DiJet110_35_Mjj650_PFMET110_DiJet140_70_Mjj900'+suffix] =  df.Filter('HLT_DiJet110_35_Mjj650_PFMET110&&vbf_selection').Histo1D(ROOT.RDF.TH1DModel('h_HLT_DiJet110_35_Mjj650_PFMET110_DiJet140_70_Mjj900'+suffix, '', len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'MetNoMu')
 
     return df, histos
 
-def AnalyzeCleanJets(df, JetRecoPtCut, L1JetPtCut):    
+def AnalyzeCleanJets(df, JetRecoPtCut, L1JetPtCut, suffix = ''):    
     histos = {}
     #Find L1 jets matched to the offline jet
-    df = df.Define('cleanJet_idxL1jet','FindL1ObjIdx(_L1jet_eta, _L1jet_phi, cleanJet_Eta, cleanJet_Phi)')
+    #df = df.Define('cleanJet_idxL1jet','FindL1ObjIdx(_L1jet_eta, _L1jet_phi, cleanJet_Eta, cleanJet_Phi)')
+    # only take jets in bx 0
+    df = df.Define('cleanJet_idxL1jet', 'FindL1ObjIdx_setBx(_L1jet_eta, _L1jet_phi, _L1jet_bx, cleanJet_Eta, cleanJet_Phi, 0)')
     df = df.Define('cleanJet_L1Pt','GetVal(cleanJet_idxL1jet,_L1jet_pt)')
     df = df.Define('cleanJet_L1Bx','GetVal(cleanJet_idxL1jet,_L1jet_bx)')
     df = df.Define('cleanJet_L1PtoverRecoPt','cleanJet_L1Pt/cleanJet_Pt')
@@ -438,7 +520,10 @@ def AnalyzeCleanJets(df, JetRecoPtCut, L1JetPtCut):
     L1PtCuts = [30., 40., 60., 80., 100., 120., 140., 160., 170., 180., 200.]
 
 
-    df = makehistosforturnons_inprobeetaranges(df, histos, etavarname='cleanJet_Eta', phivarname='cleanJet_Phi', ptvarname='cleanJet_Pt', responsevarname='cleanJet_L1PtoverRecoPt', etabins=jetEtaBins, l1varname='cleanJet_L1Pt', l1thresholds=L1PtCuts, prefix="Jet_plots", binning=jetmetpt_bins, l1thresholdforeffvsrunnb = L1JetPtCut, offlinethresholdforeffvsrunnb = JetRecoPtCut )
+    df = makehistosforturnons_inprobeetaranges(df, histos, etavarname='cleanJet_Eta', phivarname='cleanJet_Phi', ptvarname='cleanJet_Pt', responsevarname='cleanJet_L1PtoverRecoPt', etabins=jetEtaBins, l1varname='cleanJet_L1Pt', l1thresholds=L1PtCuts, prefix="Jet_plots", binning=jetmetpt_bins, l1thresholdforeffvsrunnb = L1JetPtCut, offlinethresholdforeffvsrunnb = JetRecoPtCut, suffix = suffix) 
+
+    # Make same histosgrams, in a single bin of eta (abs(eta) < 5)
+    df = makehistosforturnons_inprobeetaranges(df, histos, etavarname='cleanJet_Eta', phivarname='cleanJet_Phi', ptvarname='cleanJet_Pt', responsevarname='cleanJet_L1PtoverRecoPt', etabins=[0., 5.], l1varname='cleanJet_L1Pt', l1thresholds=[40., 180.], prefix="Jet_plots_eta_inclusive", binning=jetmetpt_bins, l1thresholdforeffvsrunnb = L1JetPtCut, offlinethresholdforeffvsrunnb = JetRecoPtCut, suffix = suffix) 
 
     
     df = df.Define('cleanHighPtJet_Eta','cleanJet_Eta[cleanJet_Pt>{}]'.format(JetRecoPtCut))
@@ -446,8 +531,8 @@ def AnalyzeCleanJets(df, JetRecoPtCut, L1JetPtCut):
     df = df.Define('cleanHighPtJet_Eta_PassL1Jet','cleanJet_Eta[cleanJet_L1Pt>={}&&cleanJet_Pt>{}]'.format(L1JetPtCut, JetRecoPtCut))
     df = df.Define('cleanHighPtJet_Phi_PassL1Jet','cleanJet_Phi[cleanJet_L1Pt>={}&&cleanJet_Pt>{}]'.format(L1JetPtCut, JetRecoPtCut))
     
-    histos["L1JetvsEtaPhi_Numerator"] = df.Histo2D(ROOT.RDF.TH2DModel('h_L1Jet{}vsEtaPhi_Numerator'.format(int(L1JetPtCut)), '', 100,-5,5,100,-3.1416,3.1416), 'cleanHighPtJet_Eta_PassL1Jet','cleanHighPtJet_Phi_PassL1Jet')
-    histos["L1JetvsEtaPhi_EtaRestricted"] = df.Histo2D(ROOT.RDF.TH2DModel('h_L1Jet{}vsEtaPhi_EtaRestricted'.format(int(L1JetPtCut)), '', 100,-5,5,100,-3.1416,3.1416), 'cleanHighPtJet_Eta','cleanHighPtJet_Phi')
+    histos["L1JetvsEtaPhi_Numerator"+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('h_L1Jet{}vsEtaPhi_Numerator'.format(int(L1JetPtCut))+suffix, '', 100,-5,5,100,-3.1416,3.1416), 'cleanHighPtJet_Eta_PassL1Jet','cleanHighPtJet_Phi_PassL1Jet')
+    histos["L1JetvsEtaPhi_EtaRestricted"+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('h_L1Jet{}vsEtaPhi_EtaRestricted'.format(int(L1JetPtCut))+suffix, '', 100,-5,5,100,-3.1416,3.1416), 'cleanHighPtJet_Eta','cleanHighPtJet_Phi')
     
 
 
@@ -458,17 +543,17 @@ def AnalyzeCleanJets(df, JetRecoPtCut, L1JetPtCut):
     df = df.Define('probeL1Jet100to150Bxplus1_Eta','cleanJet_Eta[cleanJet_Pt>90&&cleanJet_Pt<160&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150&&cleanJet_L1Bx==1]')
     df = df.Define('probeL1Jet100to150Bxplus1_Phi','cleanJet_Phi[cleanJet_Pt>90&&cleanJet_Pt<160&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150&&cleanJet_L1Bx==1]')
 
-    histos['L1Jet100to150_bxmin1_etaphi'] = df.Histo2D(ROOT.RDF.TH2DModel('L1Jet100to150_bxmin1_etaphi', '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet100to150Bxmin1_Eta', 'probeL1Jet100to150Bxmin1_Phi')
-    histos['L1Jet100to150_bx0_etaphi'] = df.Histo2D(ROOT.RDF.TH2DModel('L1Jet100to150_bx0_etaphi', '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet100to150Bx0_Eta', 'probeL1Jet100to150Bx0_Phi')
-    histos['L1Jet100to150_bxplus1_etaphi'] = df.Histo2D(ROOT.RDF.TH2DModel('L1Jet100to150_bxplus1_etaphi', '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet100to150Bxplus1_Eta', 'probeL1Jet100to150Bxplus1_Phi')
+    histos['L1Jet100to150_bxmin1_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('L1Jet100to150_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet100to150Bxmin1_Eta', 'probeL1Jet100to150Bxmin1_Phi')
+    histos['L1Jet100to150_bx0_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('L1Jet100to150_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet100to150Bx0_Eta', 'probeL1Jet100to150Bx0_Phi')
+    histos['L1Jet100to150_bxplus1_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('L1Jet100to150_bxplus1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet100to150Bxplus1_Eta', 'probeL1Jet100to150Bxplus1_Phi')
 
-
+    histos['L1Jet100to150_bxmin1_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel('L1Jet100to150_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1Jet100to150Bxmin1_Eta')
+    histos['L1Jet100to150_bx0_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel('L1Jet100to150_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1Jet100to150Bx0_Eta')
+    histos['L1Jet100to150_bxplus1_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel('L1Jet100to150_bxplus1_eta'+suffix, '', 100, -5, 5), 'probeL1Jet100to150Bxplus1_Eta')
 
     return df, histos
 
-
-
-def HFNoiseStudy(df):
+def HFNoiseStudy(df, suffix = ''):
     '''
     Offline study of HF noise.
     '''
@@ -489,28 +574,28 @@ def HFNoiseStudy(df):
     dfhfnoise = dfhfnoise.Define('HighPtJet_HFAdjacentEtaStripSize','_jethfadjacentEtaStripsSize[_jetPt>250&&((_jetEta>3.0&&_jetEta<5)||(_jetEta>-5&&_jetEta<-3.))]')
     
     
-    suffix = ['failL1Jet80', 'passL1Jet80']
+    prefix = ['failL1Jet80', 'passL1Jet80']
     df_passvsfailL1 = [dfhfnoise.Filter('Sum(passL1Pt80&&isHFJetPt250)==0'), dfhfnoise.Filter('Sum(passL1Pt80&&isHFJetPt250)>=1')]
     
-    for i, s in enumerate(suffix):
+    for i, p in enumerate(prefix):
         if i == 0:
             df_passvsfailL1[i] = df_passvsfailL1[i].Filter(stringToPrintHF)
         
 
-        histos[s+'_nhfjets'] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(s+'_nhfjets', '', 100, 0, 100), 'nHFJets')
-        histos[s+'_npv'] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(s+'_npv', '', 100, 0, 100), '_n_PV')
-        histos[s+'_runnb'] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(s+'_runnb', '', len(runnb_bins)-1, runnb_bins), '_runNb')
+        histos[p+'_nhfjets'+suffix] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(p+'_nhfjets'+suffix, '', 100, 0, 100), 'nHFJets')
+        histos[p+'_npv'+suffix] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(p+'_npv'+suffix, '', 100, 0, 100), '_n_PV')
+        histos[p+'_runnb'+suffix] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(p+'_runnb'+suffix, '', len(runnb_bins)-1, runnb_bins), '_runNb')
         '''
-        histos[s+'_photonpt'] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(s+'_photonpt', '', 100, 0, 1000), 'ref_Pt')
-        histos[s+'_ptbalance'] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(s+'_ptbalance', '', len(response_bins)-1, response_bins), 'ptbalance')
-        histos[s+'_ptbalanceL1'] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(s+'_ptbalanceL1', '', len(response_bins)-1, response_bins), 'ptbalanceL1')
+        histos[p+'_photonpt'+suffix] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(p+'_photonpt'+suffix, '', 100, 0, 1000), 'ref_Pt')
+        histos[p+'_ptbalance'+suffix] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(p+'_ptbalance'+suffix, '', len(response_bins)-1, response_bins), 'ptbalance')
+        histos[p+'_ptbalanceL1'+suffix] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(p+'_ptbalanceL1'+suffix, '', len(response_bins)-1, response_bins), 'ptbalanceL1')
         '''
-        histos[s+'_HighPtHFJet_Eta'] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(s+'_HighPtHFJet_Eta', '', 1000, -5, 5), 'HighPtHFJet_Eta')
-        histos[s+'_HighPtHFJet_Pt'] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(s+'_HighPtHFJet_Pt', '', 80, 100, 500), 'HighPtHFJet_Pt')
-        histos[s+'_HighPtJet_HFSEtaEtavsPhiPhi'] = df_passvsfailL1[i].Histo2D(ROOT.RDF.TH2DModel(s+'_HighPtJet_HFSEtaEtavsPhiPhi', '', 100, 0, 0.2, 100, 0, 0.2), 'HighPtJet_HFSEtaEta','HighPtJet_HFSPhiPhi')
-        histos[s+'_HighPtJet_HFCentralVsAdjacentEtaStripSize'] = df_passvsfailL1[i].Histo2D(ROOT.RDF.TH2DModel(s+'_HighPtJet_HFCentralVsAdjacentEtaStripSize', '', 10, 0, 10, 10, 0, 10), 'HighPtJet_HFCentralEtaStripSize', 'HighPtJet_HFAdjacentEtaStripSize')
+        histos[p+'_HighPtHFJet_Eta'+suffix] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(p+'_HighPtHFJet_Eta'+suffix, '', 1000, -5, 5), 'HighPtHFJet_Eta')
+        histos[p+'_HighPtHFJet_Pt'+suffix] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(p+'_HighPtHFJet_Pt'+suffix, '', 80, 100, 500), 'HighPtHFJet_Pt')
+        histos[p+'_HighPtJet_HFSEtaEtavsPhiPhi'+suffix] = df_passvsfailL1[i].Histo2D(ROOT.RDF.TH2DModel(p+'_HighPtJet_HFSEtaEtavsPhiPhi'+suffix, '', 100, 0, 0.2, 100, 0, 0.2), 'HighPtJet_HFSEtaEta','HighPtJet_HFSPhiPhi')
+        histos[p+'_HighPtJet_HFCentralVsAdjacentEtaStripSize'+suffix] = df_passvsfailL1[i].Histo2D(ROOT.RDF.TH2DModel(p+'_HighPtJet_HFCentralVsAdjacentEtaStripSize'+suffix, '', 10, 0, 10, 10, 0, 10), 'HighPtJet_HFCentralEtaStripSize', 'HighPtJet_HFAdjacentEtaStripSize')
 
-        histos[s+'_met'] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(s+'_met', '', 100,0,500), '_met')
+        histos[p+'_met'+suffix] = df_passvsfailL1[i].Histo1D(ROOT.RDF.TH1DModel(p+'_met'+suffix, '', 100,0,500), '_met')
 
 
 
@@ -535,16 +620,16 @@ def PtBalanceSelection(df):
     df = df.Define('probe_Phi','cleanJet_Phi[0]')
     return df
 
-def AnalyzePtBalance(df):
+def AnalyzePtBalance(df, suffix = ''):
     histos = {}
     df_JetsBinnedInEta ={}
-    histos['L1JetvsEtaPhi'] = df.Histo3D(ROOT.RDF.TH3DModel('h_L1PtBalanceVsEtaPhi', 'ptbalanceL1', 100, -5, 5, 100, -3.1416, 3.1416, 100, 0, 2), 'probe_Eta','probe_Phi','ptbalanceL1')
+    histos['L1JetvsEtaPhi'+suffix] = df.Histo3D(ROOT.RDF.TH3DModel('h_L1PtBalanceVsEtaPhi'+suffix, 'ptbalanceL1', 100, -5, 5, 100, -3.1416, 3.1416, 100, 0, 2), 'probe_Eta','probe_Phi','ptbalanceL1')
     for i in range(len(jetEtaBins)-1):
         str_bineta = "eta{}to{}".format(jetEtaBins[i],jetEtaBins[i+1]).replace(".","p")
         df_JetsBinnedInEta[str_bineta] = df.Filter('abs(cleanJet_Eta[0])>={}&&abs(cleanJet_Eta[0])<{}'.format(jetEtaBins[i],jetEtaBins[i+1]))
-        histos['RecoJetvsRunNb'+str_bineta] = df_JetsBinnedInEta[str_bineta].Histo2D(ROOT.RDF.TH2DModel('h_PtBalanceVsRunNb_{}'.format(str_bineta), 'ptbalance', len(runnb_bins)-1, runnb_bins, len(response_bins)-1, response_bins), '_runNb','ptbalance')
-        histos['L1JetvsRunNb'+str_bineta] = df_JetsBinnedInEta[str_bineta].Histo2D(ROOT.RDF.TH2DModel('h_L1PtBalanceVsRunNb_{}'.format(str_bineta), 'ptbalanceL1', len(runnb_bins)-1, runnb_bins, len(response_bins)-1, response_bins), '_runNb','ptbalanceL1')
-        histos['L1JetvsPU'+str_bineta] = df_JetsBinnedInEta[str_bineta].Histo2D(ROOT.RDF.TH2DModel('h_L1PtBalanceVsPU_{}'.format(str_bineta), 'ptbalanceL1', 100, 0, 100, 100, 0, 2), '_n_PV','ptbalanceL1')
+        histos['RecoJetvsRunNb'+str_bineta+suffix] = df_JetsBinnedInEta[str_bineta].Histo2D(ROOT.RDF.TH2DModel('h_PtBalanceVsRunNb_{}'.format(str_bineta)+suffix, 'ptbalance', len(runnb_bins)-1, runnb_bins, len(response_bins)-1, response_bins), '_runNb','ptbalance')
+        histos['L1JetvsRunNb'+str_bineta+suffix] = df_JetsBinnedInEta[str_bineta].Histo2D(ROOT.RDF.TH2DModel('h_L1PtBalanceVsRunNb_{}'.format(str_bineta)+suffix, 'ptbalanceL1', len(runnb_bins)-1, runnb_bins, len(response_bins)-1, response_bins), '_runNb','ptbalanceL1')
+        histos['L1JetvsPU'+str_bineta+suffix] = df_JetsBinnedInEta[str_bineta].Histo2D(ROOT.RDF.TH2DModel('h_L1PtBalanceVsPU_{}'.format(str_bineta)+suffix, 'ptbalanceL1', 100, 0, 100, 100, 0, 2), '_n_PV','ptbalanceL1')
 
         
     return df, histos

--- a/helpers/helper.py
+++ b/helpers/helper.py
@@ -204,7 +204,7 @@ def ZMuMu_MuSelection(df):
 
     df = df.Define('isTag','_lPt>25&&abs(_lpdgId)==13&&_lPassTightID&&_lpassHLT_IsoMu24')
     df = df.Filter('Sum(isTag)>0')
-    df = df.Define('isProbe','_lPt>5&&abs(_lpdgId)==13&&_lPassTightID&& (Sum(isTag)>=2|| isTag==0)')
+    df = df.Define('isProbe','_lPt>3&&abs(_lpdgId)==13&&_lPassTightID&& (Sum(isTag)>=2|| isTag==0)')
     df = df.Filter('_mll>80&&_mll<100')
 
     df = df.Define('probe_Pt','_lPt[isProbe]')

--- a/l1macros/condorsubmission/scriptcondor_performances.sh
+++ b/l1macros/condorsubmission/scriptcondor_performances.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-cd /user/lathomas/L1Studies/SampleGeneration/SingleNeutrinoPU1/CMSSW_12_2_1/src
+cd /user/hevard/CMSSW_12_4_8/src/
 cmsenv 
-cd /user/lathomas/PortingCodeToGitIIHECMS/CMSSW_12_4_8/src/MacrosNtuples/l1macros/
+cd /user/hevard/CMSSW_12_4_8/src/MacrosNtuples/l1macros/
 
 python3 performances.py --max_events -1 -i $1 -o $2 -c $3
 

--- a/l1macros/condorsubmission/scriptcondor_performances_template.sub
+++ b/l1macros/condorsubmission/scriptcondor_performances_template.sub
@@ -1,13 +1,16 @@
 # Files
 executable = scriptcondor_performances.sh
-output = /user/lathomas/PortingCodeToGitIIHECMS/CMSSW_12_4_8/src/MacrosNtuples/l1macros/condorsubmission/OUTPUTDIR/log/scriptcondor_$(Process).out
-error = /user/lathomas/PortingCodeToGitIIHECMS/CMSSW_12_4_8/src/MacrosNtuples/l1macros/condorsubmission/OUTPUTDIR/log/scriptcondor_$(Process).err
-log = /user/lathomas/PortingCodeToGitIIHECMS/CMSSW_12_4_8/src/MacrosNtuples/l1macros/condorsubmission/OUTPUTDIR/log/scriptcondor_$(Process).log
+#output = /user/lathomas/PortingCodeToGitIIHECMS/CMSSW_12_4_8/src/MacrosNtuples/l1macros/condorsubmission/OUTPUTDIR/log/scriptcondor_$(Process).out
+#error = /user/lathomas/PortingCodeToGitIIHECMS/CMSSW_12_4_8/src/MacrosNtuples/l1macros/condorsubmission/OUTPUTDIR/log/scriptcondor_$(Process).err
+#log = /user/lathomas/PortingCodeToGitIIHECMS/CMSSW_12_4_8/src/MacrosNtuples/l1macros/condorsubmission/OUTPUTDIR/log/scriptcondor_$(Process).log
+output = /user/hevard/CMSSW_12_4_8/src/MacrosNtuples/l1macros/condorsubmission/OUTPUTDIR/log/scriptcondor_$(Process).out
+error = /user/hevard/CMSSW_12_4_8/src/MacrosNtuples/l1macros/condorsubmission/OUTPUTDIR/log/scriptcondor_$(Process).err
+log = /user/hevard/CMSSW_12_4_8/src/MacrosNtuples/l1macros/condorsubmission/OUTPUTDIR/log/scriptcondor_$(Process).log
 #arguments    = $(Process)
 
 
 transfer_input_files = $(filename)
-arguments            = $(filename)  /user/lathomas/PortingCodeToGitIIHECMS/CMSSW_12_4_8/src/MacrosNtuples/l1macros/condorsubmission/OUTPUTDIR/output_$(Process).root CHANNEL
+arguments            = $(filename)  /user/hevard/CMSSW_12_4_8/src/MacrosNtuples/l1macros/condorsubmission/OUTPUTDIR/output_$(Process).root CHANNEL
 
 
 

--- a/l1macros/condorsubmission/submit_all.sh
+++ b/l1macros/condorsubmission/submit_all.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+#for run in 'C1' 'D1' 'D2' 'E1' 'F1' 'G1'
+for run in 'G1'
+do
+    #for skim in "Muon","ZToMuMu" "Muon","SingleMuforJME" "EGamma","ZToEE" "EGamma","SinglePhotonforJME"
+    for skim in "Muon","ZToMuMu"
+    do 
+        IFS=","
+        set $skim
+        dir=`ls -d1 /pnfs/iihe/cms/store/user/hevard/$1/Run2022${run:0:1}_PromptReco_v${run:1:1}_DataRun3_L1Study_$2/22* | tail -n 1`
+        #dir=`ls -d1 /pnfs/iihe/cms/store/user/hevard/$1/Run2022${run:0:1}_PromptReco_v${run:1:1}_DataRun3_L1Study_$2/* | tail -n 1`
+        #dir=`ls -d1 /pnfs/iihe/cms/store/user/hevard/$1/Run2022${run:0:1}_PromptReco_v${run:1:1}_DataRun3_L1Study_$2/* | tail -n 2 | head -n 1`
+
+        case $2 in
+            "ZToMuMu")
+                condor_skim="ZToMuMu"
+                ;;
+
+            "SingleMuforJME")
+                condor_skim="MuonJet"
+                ;;
+
+            "ZToEE")
+                condor_skim="ZToEE"
+                ;;
+
+            "SinglePhotonforJME")
+                condor_skim="PhotonJet"
+                ;;
+        esac
+
+        #outdir="2022Run${run:0:1}v${run:1:1}_golden"
+        outdir="2022Run${run:0:1}v${run:1:1}"
+
+        #condor_submit submit.sub skim=$condor_skim input_files=$dir/*/*.root out_dir=$outdir/outputcondor_$condor_skim
+        #echo SubmitToCondor.sh "$outdir"/outputcondor_"$condor_skim" "$condor_skim" \'"$dir/*/*.root"\'
+        sh SubmitToCondor.sh outdir/"$outdir"/outputcondor_"$condor_skim" "$condor_skim" "$dir/*/*.root"
+
+
+    done
+done
+
+#./submit.sh ZToMuMu "/pnfs/iihe/cms/store/user/hevard/SingleMuon/Run2022C_PromptReco_v1_DataRun3_L1Study_ZToMuMu/221214_155554/*/*.root" 2022RunCv1_golden/outputcondor_SingleMuon_ZToMuMu
+#./submit.sh MuonJet "/pnfs/iihe/cms/store/user/hevard/SingleMuon/Run2022C_PromptReco_v1_DataRun3_L1Study_SingleMuforJME/221214_155734/*/*.root" 2022RunCv1_golden/outputcondor_SingleMuon_MuonJet
+
+
+# 2018D
+
+#sh SubmitToCondor.sh MuonJet_2018D MuonJet /pnfs/iihe/cms/store/user/lathomas/SingleMuon/Run2018D_UL2018_MiniAODv2_v3_DataUL2018D_L1Study_SingleMuforJME/220923_115303/0000/\*.root
+#sh SubmitToCondor.sh ZToMuMu_2018D ZToMuMu /pnfs/iihe/cms/store/user/lathomas/SingleMuon/Run2018D_UL2018_MiniAODv2_v3_DataUL2018D_L1Study_ZToMuMu/220923_114505/0000/\*.root
+#sh SubmitToCondor.sh ZToEE_2018D ZToEE /pnfs/iihe/cms/store/user/lathomas/EGamma/Run2018D_UL2018_MiniAODv2_v2_DataRun3_L1Study_ZToEE/220913_203229/000\*/\*.root
+#sh SubmitToCondor.sh PhotonJet_2018D PhotonJet /pnfs/iihe/cms/store/user/lathomas/EGamma/Run2018D_UL2018_MiniAODv2_v2_DataUL2018D_L1Study_SinglePhotonforJME/220923_120114/000\*/\*.root

--- a/l1macros/performances.py
+++ b/l1macros/performances.py
@@ -33,6 +33,8 @@ def main():
                         -ZToMuMu: For L1 muon studies with Z->mumu
                         -ZToEE: For L1 EG studies with Z->ee''', 
                         type=str, default='PhotonJet')
+    parser.add_argument("--plot_nvtx", dest="plot_nvtx", help="Whether to save additional plots in bins of nvtx. Boolean, default = False", type=bool, default=False)
+    parser.add_argument("--nvtx_bins", dest="nvtx_bins", help="Edges of the nvtx bins to use if plotNvtx is set to True. Default=[10, 20, 30, 40, 50, 60]", nargs='+', type=int, default=[10, 20, 30, 40, 50, 60])
     args = parser.parse_args() 
 
     
@@ -48,6 +50,19 @@ def main():
         elif args.channel == 'ZToEE':
             inputFile = '/user/lathomas/Public/L1Studies/ZToEE.root'
 
+    ### Create filters and suffix, if needed, to later run on bins of nvtx
+
+    filter_list = ["true"]
+    suffix_list = [""]
+
+    # bins of nvtx
+    if args.plot_nvtx == True:
+        filter_list += ["_n_PV>{}&&_n_PV<{}".format(low, high) for (low, high) \
+                in zip(args.nvtx_bins[:-1],args.nvtx_bins[1:])]
+        suffix_list += ["_nvtx{}to{}".format(low, high) for (low, high) \
+                in zip(args.nvtx_bins[:-1],args.nvtx_bins[1:])]
+
+    ###
 
     df = ROOT.RDataFrame('ntuplizer/tree', inputFile)    
     nEvents = df.Count().GetValue()
@@ -76,32 +91,71 @@ def main():
         print("Channel {} does not exist".format(args.channel))
         return 
 
+    # add nvtx histo
+    nvtx_histo = df.Histo1D(ROOT.RDF.TH1DModel("h_nvtx" , "Number of reco vertices;N_{vtx};Events"  ,    100, 0., 100.), "_n_PV")
+    nvtx_histo.GetValue().Write()
+        
     if args.channel == 'PhotonJet':
         df = SinglePhotonSelection(df) 
         
         df = CleanJets(df)
         
-        df, histos_jets = AnalyzeCleanJets(df, 200, 100) 
-        
-        df = PtBalanceSelection(df)
-        
-        df, histos_balance = AnalyzePtBalance(df)
-        
-        df_report = df.Report()
-        
-        df, histos_hf = HFNoiseStudy(df)
+        # make copies of df for each bin of nvtx (+1 copy of the original)
+        df_list = [df.Filter(nvtx_cut) for nvtx_cut in filter_list]
 
-        #Selection is over. Now do some plotting
+        all_histos_jets = {}
+        all_histos_balance = {}
+        all_histos_hf = {}
 
-        for i in histos_jets:
-            histos_jets[i].GetValue().Write()
+        # run for each bin of nvtx:
+        for i, df_element in enumerate(df_list):
+            df_element, histos_jets = AnalyzeCleanJets(df_element, 200, 100, suffix = suffix_list[i])
+            df_element = PtBalanceSelection(df_element)
+            df_element, histos_balance = AnalyzePtBalance(df_element, suffix = suffix_list[i])
+            #df_report = df_element.Report()
+            df_element, histos_hf = HFNoiseStudy(df_element, suffix = suffix_list[i])
 
-        for i in histos_balance:
-            histos_balance[i].GetValue().Write()
+            for key, val in histos_jets.items():
+                all_histos_jets[key] = val
+
+            for key, val in histos_balance.items():
+                all_histos_balance[key] = val
+
+            for key, val in histos_hf.items():
+                all_histos_hf[key] = val
+
+            #df_report.Print()
+
+        for i in all_histos_jets:
+            all_histos_jets[i].GetValue().Write()
             
-        for i in histos_hf:
-            histos_hf[i].GetValue().Write()
-        df_report.Print()
+        for i in all_histos_balance:
+            all_histos_balance[i].GetValue().Write()
+            
+        for i in all_histos_hf:
+            all_histos_hf[i].GetValue().Write()
+
+#        df, histos_jets = AnalyzeCleanJets(df, 200, 100) 
+#        
+#        df = PtBalanceSelection(df)
+#        
+#        df, histos_balance = AnalyzePtBalance(df)
+#        
+#        df_report = df.Report()
+#        
+#        df, histos_hf = HFNoiseStudy(df)
+#
+#        #Selection is over. Now do some plotting
+#
+#        for i in histos_jets:
+#            histos_jets[i].GetValue().Write()
+#
+#        for i in histos_balance:
+#            histos_balance[i].GetValue().Write()
+#            
+#        for i in histos_hf:
+#            histos_hf[i].GetValue().Write()
+#        df_report.Print()
         
         
     if args.channel == 'MuonJet':
@@ -109,40 +163,98 @@ def main():
         
         df = CleanJets(df)
         
-        df, histos_jets = AnalyzeCleanJets(df, 100, 50) 
-        
-        df, histos_sum = EtSum(df)
-        
-        df_report = df.Report()
-        
-        df, histos_hf = HFNoiseStudy(df)
+        # make copies of df for each bin of nvtx (+1 copy of the original)
+        df_list = [df.Filter(nvtx_cut) for nvtx_cut in filter_list]
 
-        #Selection is over. Now do some plotting
-        
-        for i in histos_jets:
-            histos_jets[i].GetValue().Write()
+        all_histos_jets = {}
+        all_histos_sum = {}
+        all_histos_hf = {}
+
+        for i, df_element in enumerate(df_list):
+            df_element, histos_jets = AnalyzeCleanJets(df_element, 100, 50, suffix = suffix_list[i]) 
+            df_element, histos_sum = EtSum(df_element, suffix = suffix_list[i])
+            df_element, histos_hf = HFNoiseStudy(df, suffix = suffix_list[i])
+
+            for key, val in histos_jets.items():
+                all_histos_jets[key] = val
+
+            for key, val in histos_sum.items():
+                all_histos_sum[key] = val
+
+            for key, val in histos_hf.items():
+                all_histos_hf[key] = val
+
+        for i in all_histos_jets:
+            all_histos_jets[i].GetValue().Write()
             
-        for i in histos_sum:
-            histos_sum[i].GetValue().Write()
+        for i in all_histos_sum:
+            all_histos_sum[i].GetValue().Write()
+
+        for i in all_histos_hf:
+            all_histos_hf[i].GetValue().Write()
             
-        for i in histos_hf:
-            histos_hf[i].GetValue().Write()
-                
-        df_report.Print()
+#        df, histos_jets = AnalyzeCleanJets(df, 100, 50) 
+#        
+#        df, histos_sum = EtSum(df)
+#        
+#        df_report = df.Report()
+#        
+#        df, histos_hf = HFNoiseStudy(df)
+#
+#        #Selection is over. Now do some plotting
+#        
+#        for i in histos_jets:
+#            histos_jets[i].GetValue().Write()
+#            
+#        for i in histos_sum:
+#            histos_sum[i].GetValue().Write()
+#            
+#        for i in histos_hf:
+#            histos_hf[i].GetValue().Write()
+#                
+#        df_report.Print()
 
     if args.channel == 'ZToEE':
         df = ZEE_EleSelection(df)
-        df, histos = ZEE_Plots(df)
+
+        # make copies of df for each bin of nvtx (+1 copy of the original)
+        df_list = [df.Filter(nvtx_cut) for nvtx_cut in filter_list]
+        all_histos = {}
+
+        for i, df_element in enumerate(df_list):
+            df_element, histos = ZEE_Plots(df_element, suffix = suffix_list[i])
+
+            for key, val in histos.items():
+                all_histos[key] = val
         
-        for i in histos:
-            histos[i].GetValue().Write()
+        for i in all_histos:
+            all_histos[i].GetValue().Write()
+
+#        df, histos = ZEE_Plots(df)
+#        
+#        for i in histos:
+#            histos[i].GetValue().Write()
 
     if args.channel == 'ZToMuMu':
         df = ZMuMu_MuSelection(df)
-        df, histos = ZMuMu_Plots(df)
 
-        for i in histos:
-            histos[i].GetValue().Write()
+        # make copies of df for each bin of nvtx (+1 copy of the original)
+        df_list = [df.Filter(nvtx_cut) for nvtx_cut in filter_list]
+        all_histos = {}
+
+        for i, df_element in enumerate(df_list):
+            df_element, histos = ZMuMu_Plots(df_element, suffix = suffix_list[i])
+
+            for key, val in histos.items():
+                all_histos[key] = val
+
+        for i in all_histos:
+            all_histos[i].GetValue().Write()
+
+#        df, histos = ZMuMu_Plots(df)
+#
+#        for i in histos:
+#            histos[i].GetValue().Write()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changes the way pre-/postfiring histograms are computed, by matching reco objects to L1 objects in a specific bunch crossing
Saves some additional histograms, like the pre-/postfiring as a function of eta only and some histograms the compute efficiencies of triggers, using a given DiJet selection.
Makes it possible to compute all histograms in bins of nvtx.