### PR TITLE
Add more jet prefiring monitoring

### DIFF
--- a/config_cards/full_DiJet.yaml
+++ b/config_cards/full_DiJet.yaml
@@ -1,0 +1,59 @@
+### The different of regions of eta
+Regions:
+    # <label>: [<low bound>, <high bound>]
+    # label is the string inserted in histogram and plot names
+    # low bound is the lowest value of abs(eta) for that region (inclusive)
+    # high bound is the highest value of abs(eta) for that region (exclusive)
+    Barrel: [0.0, 1.3]
+    Endcap1: [1.3, 2.5]
+    Endcap2: [2.5, 3.0]
+    HF1: [3.0, 3.5]
+    HF2: [3.5, 4.0]
+    HF3: [4.0, 5.0]
+    AllEta: [0.0, 5.0]
+### The thresholds to draw the turn-on of
+# Thresholds: [<thr 1>, <thr 2>, ...]
+# thr # are the different threshold values (in GeV) to use
+Thresholds: [30., 40., 60., 80., 100., 120., 140., 160., 170., 180., 200.]
+### These are some boolean fields to select to compute and draw some plots or not
+#   these fields need to exist, and must be set to either true or false.
+# All the Turn On plots:
+TurnOns: true
+# Response vs Pt and vs Run Nb. These require the AllQual quality to be computed.
+Response: true
+# All the pre/post firing plots (vs Eta Phi, vs Eta, for Mu 10 to 21 and Mu 22)
+Prefiring: true
+# Efficiency vs Run Nb and vs Eta Phi
+Efficiency: true
+# Pt Balance
+PtBalance: true
+# HF noise
+HF_noise: true
+### Settings for the plots in bins of nvtx
+PU_plots:
+    # Whether or not to compute the histograms for each bin of nvtx.
+    # this field needs to exist, and must be set to either true or false.
+    make_histos: true
+    # The bins of nvtx to use
+    # nvtx_bins: [<bin 1>, <bin 2>, ...]
+    # using this will make copies of each histogram for each bin
+    # [<bin i>, <bin i+1>], with an inclusive low bound and exclusive high bound.
+    nvtx_bins: [10, 20, 30, 40, 50, 60]
+    # These additionnal thresholds can be set, and only affect the plotting of the figures,
+    # not the computing of the histograms. 
+    # draw_thresholds: [<thr 1>, <thr 2>, ...]
+    # For each thr #, a turn on figure will be made, 
+    # comparing the turn on of this threshold accross all bins of nvtx
+    # For this to be possible, make_histos has to be set to true,
+    # and the  thr # values also need to be passed to Thresholds.
+    draw_thresholds: [40.]
+#
+#
+#
+# for debugging purposses
+#TurnOns: false
+#Efficiency: false
+#Prefiring: false
+#Response: false
+#PtBalance: false
+#HF_noise: false

--- a/helpers/Helper.h
+++ b/helpers/Helper.h
@@ -23,13 +23,10 @@ double deltaphi_offlinemustation2_l1mu(int charge, double mupt, double mueta, do
 
     if(dphi> M_PI) dphi -= 2* M_PI;
     if(dphi<- M_PI) dphi += 2* M_PI;
-
     return dphi;
 }  
 
-// ==============================
-
-vector<int> FindL1JetIdx(ROOT::VecOps::RVec<float>L1Obj_eta, ROOT::VecOps::RVec<float>L1Obj_phi, ROOT::VecOps::RVec<float>recoObj_Eta, ROOT::VecOps::RVec<float>recoObj_Phi, ROOT::VecOps::RVec<int>L1Obj_CutVar={}, int CutVar=-1){
+vector<int> FindL1ObjIdx(ROOT::VecOps::RVec<float>L1Obj_eta, ROOT::VecOps::RVec<float>L1Obj_phi, ROOT::VecOps::RVec<float>recoObj_Eta, ROOT::VecOps::RVec<float>recoObj_Phi, ROOT::VecOps::RVec<int>L1Obj_CutVar={}, int CutVar=-1){
   vector <int> result={};
   for(unsigned int i = 0; i<recoObj_Eta.size(); i++){
     double drmin = 0.4; 
@@ -51,40 +48,12 @@ vector<int> FindL1JetIdx(ROOT::VecOps::RVec<float>L1Obj_eta, ROOT::VecOps::RVec<
   }
   return result;
 }
-
-vector<int> FindL1JetIdx_setBx(ROOT::VecOps::RVec<float>L1Obj_eta, ROOT::VecOps::RVec<float>L1Obj_phi, ROOT::VecOps::RVec<float>L1Obj_bx, ROOT::VecOps::RVec<float>recoObj_Eta, ROOT::VecOps::RVec<float>recoObj_Phi, int bx, ROOT::VecOps::RVec<int>L1Obj_CutVar={}, int CutVar=-1){
-  vector <int> result={};
-  for(unsigned int i = 0; i<recoObj_Eta.size(); i++){
-    double drmin = 0.4; 
-    int idx = -1;
-    for(unsigned int j = 0; j<L1Obj_eta.size(); j++){
-
-      if(L1Obj_CutVar.size()==L1Obj_eta.size()){
-	if(L1Obj_CutVar[j]<CutVar)continue;
-      }
-      if(L1Obj_bx[j] != bx){
-          continue;
-      }
-      double deta = abs(recoObj_Eta[i]-L1Obj_eta[j]);
-      double dphi = abs(acos(cos(recoObj_Phi[i]-L1Obj_phi[j]))); 
-      double dr = sqrt(deta*deta+dphi*dphi);
-      if(dr<=drmin){ 
-	drmin = dr; 
-	idx = j;
-      }
-    }
-    result.push_back(idx);
-  }
-  return result;
-}
-
-// ==========================================
 
 vector<int> FindL1MuIdx(ROOT::VecOps::RVec<float>L1Obj_eta, ROOT::VecOps::RVec<float>L1Obj_phi, ROOT::VecOps::RVec<float>recoObj_Eta, ROOT::VecOps::RVec<float>recoObj_Phi, 
         ROOT::VecOps::RVec<float>recoObj_Pt, ROOT::VecOps::RVec<int>charge, ROOT::VecOps::RVec<int>L1Obj_CutVar={}, int CutVar=-1){
   vector <int> result={};
   for(unsigned int i = 0; i<recoObj_Eta.size(); i++){
-    double drmin = 0.2; 
+    double drmin = 0.4; 
     int idx = -1;
     for(unsigned int j = 0; j<L1Obj_eta.size(); j++){
 
@@ -92,9 +61,9 @@ vector<int> FindL1MuIdx(ROOT::VecOps::RVec<float>L1Obj_eta, ROOT::VecOps::RVec<f
 	if(L1Obj_CutVar[j]<CutVar)continue;
       }
       double deta = abs(recoObj_Eta[i]-L1Obj_eta[j]);
-      // Delta Phi correction at station 2
-      double dphi = deltaphi_offlinemustation2_l1mu(charge[i], recoObj_Pt[i], recoObj_Eta[i], recoObj_Phi[i], L1Obj_phi[j]);
+      double dphi = deltaphi_offlinemustation2_l1mu(charge[j], recoObj_Pt[i], recoObj_Eta[i], recoObj_Phi[i], L1Obj_phi[j]);
       double dr = sqrt(deta*deta+dphi*dphi);
+      
       if(dr<=drmin){ 
 	drmin = dr; 
 	idx = j;
@@ -105,11 +74,13 @@ vector<int> FindL1MuIdx(ROOT::VecOps::RVec<float>L1Obj_eta, ROOT::VecOps::RVec<f
   return result;
 }
 
+// Match objects only in a given bunch crossing
 vector<int> FindL1MuIdx_setBx(ROOT::VecOps::RVec<float>L1Obj_eta, ROOT::VecOps::RVec<float>L1Obj_phi, ROOT::VecOps::RVec<float>L1Obj_bx, ROOT::VecOps::RVec<float>recoObj_Eta, ROOT::VecOps::RVec<float>recoObj_Phi, 
         ROOT::VecOps::RVec<float>recoObj_Pt, ROOT::VecOps::RVec<int>charge, int bx, ROOT::VecOps::RVec<int>L1Obj_CutVar={}, int CutVar=-1){
   vector <int> result={};
   for(unsigned int i = 0; i<recoObj_Eta.size(); i++){
-    double drmin = 0.2; 
+    //double drmin = 0.4; 
+    double drmin = 0.6; 
     int idx = -1;
     for(unsigned int j = 0; j<L1Obj_eta.size(); j++){
 
@@ -121,7 +92,7 @@ vector<int> FindL1MuIdx_setBx(ROOT::VecOps::RVec<float>L1Obj_eta, ROOT::VecOps::
       }
       double deta = abs(recoObj_Eta[i]-L1Obj_eta[j]);
       // Delta Phi correction at station 2
-      double dphi = deltaphi_offlinemustation2_l1mu(charge[i], recoObj_Pt[i], recoObj_Eta[i], recoObj_Phi[i], L1Obj_phi[j]);
+      double dphi = deltaphi_offlinemustation2_l1mu(charge[j], recoObj_Pt[i], recoObj_Eta[i], recoObj_Phi[i], L1Obj_phi[j]);
       double dr = sqrt(deta*deta+dphi*dphi);
       if(dr<=drmin){ 
 	drmin = dr; 
@@ -133,41 +104,11 @@ vector<int> FindL1MuIdx_setBx(ROOT::VecOps::RVec<float>L1Obj_eta, ROOT::VecOps::
   return result;
 }
 
-// ==================================================
-
-vector<int> FindL1EGIdx(ROOT::VecOps::RVec<float>L1Obj_eta, ROOT::VecOps::RVec<float>L1Obj_phi, ROOT::VecOps::RVec<float>recoObj_Eta, ROOT::VecOps::RVec<float>recoObj_Phi, ROOT::VecOps::RVec<float>recoObj_Pt, ROOT::VecOps::RVec<int>L1Obj_CutVar={}, int CutVar=-1){
+vector<int> FindL1ObjIdx_setBx(ROOT::VecOps::RVec<float>L1Obj_eta, ROOT::VecOps::RVec<float>L1Obj_phi, ROOT::VecOps::RVec<float>L1Obj_bx, ROOT::VecOps::RVec<float>recoObj_Eta, ROOT::VecOps::RVec<float>recoObj_Phi, int bx, ROOT::VecOps::RVec<int>L1Obj_CutVar={}, int CutVar=-1){
   vector <int> result={};
   for(unsigned int i = 0; i<recoObj_Eta.size(); i++){
-    double drmin = 0.3; 
-    if(recoObj_Pt[i] > 10.){
-        drmin = 0.2;
-    }
-    int idx = -1;
-    for(unsigned int j = 0; j<L1Obj_eta.size(); j++){
-
-      if(L1Obj_CutVar.size()==L1Obj_eta.size()){
-	if(L1Obj_CutVar[j]<CutVar)continue;
-      }
-      double deta = abs(recoObj_Eta[i]-L1Obj_eta[j]);
-      double dphi = abs(acos(cos(recoObj_Phi[i]-L1Obj_phi[j]))); 
-      double dr = sqrt(deta*deta+dphi*dphi);
-      if(dr<=drmin){ 
-	drmin = dr; 
-	idx = j;
-      }
-    }
-    result.push_back(idx);
-  }
-  return result;
-}
-
-vector<int> FindL1EGIdx_setBx(ROOT::VecOps::RVec<float>L1Obj_eta, ROOT::VecOps::RVec<float>L1Obj_phi, ROOT::VecOps::RVec<float>L1Obj_bx, ROOT::VecOps::RVec<float>recoObj_Eta, ROOT::VecOps::RVec<float>recoObj_Phi, ROOT::VecOps::RVec<float>recoObj_Pt, int bx, ROOT::VecOps::RVec<int>L1Obj_CutVar={}, int CutVar=-1){
-  vector <int> result={};
-  for(unsigned int i = 0; i<recoObj_Eta.size(); i++){
-    double drmin = 0.3; 
-    if(recoObj_Pt[i] > 10.){
-        drmin = 0.2;
-    }
+    //double drmin = 0.4; 
+    double drmin = 0.6; 
     int idx = -1;
     for(unsigned int j = 0; j<L1Obj_eta.size(); j++){
 
@@ -189,8 +130,6 @@ vector<int> FindL1EGIdx_setBx(ROOT::VecOps::RVec<float>L1Obj_eta, ROOT::VecOps::
   }
   return result;
 }
-
-// =================================================
 
 ROOT::VecOps::RVec<float> GetVal(ROOT::VecOps::RVec<int>idxL1Obj, ROOT::VecOps::RVec<float>L1Obj_val){
   ROOT::VecOps::RVec<float> result ={}; 
@@ -356,21 +295,21 @@ bool L1SeedPtLeadDoubleJetMassMin(ROOT::VecOps::RVec<float>pt, ROOT::VecOps::RVe
 float mll(ROOT::VecOps::RVec<float>l_pt, ROOT::VecOps::RVec<float>l_eta, ROOT::VecOps::RVec<float>l_phi, ROOT::VecOps::RVec<bool>l_isTag, ROOT::VecOps::RVec<bool>l_isProbe){
   float mll = -1.;
   for(unsigned int i = 0; i < l_pt.size(); i++){
-      if(l_pt.size() < 2) continue;
-      if(l_isProbe[i] == false) continue;
-      for(unsigned int j = 0; j < l_pt.size(); j++){
-          if(i == j) continue;
-          if(l_isTag[j] == false) continue;
+    if(l_pt.size() < 2) continue;
+    if(l_isProbe[i] == false) continue;
+    for(unsigned int j = 0; j < l_pt.size(); j++){
+      if(i == j) continue;
+      if(l_isTag[j] == false) continue;
 
-          TLorentzVector lep1;
-          TLorentzVector lep2;
-          lep1.SetPtEtaPhiE(l_pt[i], l_eta[i], l_phi[i], l_pt[i] * cosh(l_eta[i]));
-          lep2.SetPtEtaPhiE(l_pt[j], l_eta[j], l_phi[j], l_pt[j] * cosh(l_eta[j]));
+      TLorentzVector lep1;
+      TLorentzVector lep2;
+      lep1.SetPtEtaPhiE(l_pt[i], l_eta[i], l_phi[i], l_pt[i] * cosh(l_eta[i]));
+      lep2.SetPtEtaPhiE(l_pt[j], l_eta[j], l_phi[j], l_pt[j] * cosh(l_eta[j]));
 
-          if(lep1.DeltaR(lep2) > 0.4){
-            mll = (lep1+lep2).Mag();
-          }
+      if(lep1.DeltaR(lep2) > 0.4){
+	mll = (lep1+lep2).Mag();
       }
+    }
   }
   return mll;
 }
@@ -379,53 +318,50 @@ vector<vector<vector<float>>> dR_mll(ROOT::VecOps::RVec<float>l_pt, ROOT::VecOps
   //float mll = -1.;
   vector<vector<vector<float>>> result = {};
   if(l_pt.size() < 2){
-      return result;
+    return result;
   }
   for(unsigned int i = 0; i < l_pt.size(); i++){
-      vector<vector<float>> line = {};
-      for(unsigned int j = 0; j < l_pt.size(); j++){
+    vector<vector<float>> line = {};
+    for(unsigned int j = 0; j < l_pt.size(); j++){
 
-          float DeltaR = -1;
-          float mll = -1;
-          vector<float> pair = {};
+      float DeltaR = -1;
+      float mll = -1;
+      vector<float> pair = {};
 
-          if((l_isProbe[i] == false)||(l_isTag[j] == false)||(i == j)){
-              pair.push_back(DeltaR);
-              pair.push_back(mll);
-              line.push_back(pair);
-              continue;
-          }
-
-          TLorentzVector lep1;
-          TLorentzVector lep2;
-          lep1.SetPtEtaPhiE(l_pt[i], l_eta[i], l_phi[i], l_pt[i] * cosh(l_eta[i]));
-          lep2.SetPtEtaPhiE(l_pt[j], l_eta[j], l_phi[j], l_pt[j] * cosh(l_eta[j]));
-
-          DeltaR = lep1.DeltaR(lep2);
-          mll = (lep1+lep2).Mag();
-
-          pair.push_back(DeltaR);
-          pair.push_back(mll);
-          line.push_back(pair);
-
+      if((l_isProbe[i] == false)||(l_isTag[j] == false)||(i == j)){
+	pair.push_back(DeltaR);
+	pair.push_back(mll);
+	line.push_back(pair);
+	continue;
       }
-      result.push_back(line);
+
+      TLorentzVector lep1;
+      TLorentzVector lep2;
+      lep1.SetPtEtaPhiE(l_pt[i], l_eta[i], l_phi[i], l_pt[i] * cosh(l_eta[i]));
+      lep2.SetPtEtaPhiE(l_pt[j], l_eta[j], l_phi[j], l_pt[j] * cosh(l_eta[j]));
+
+      DeltaR = lep1.DeltaR(lep2);
+      mll = (lep1+lep2).Mag();
+
+      pair.push_back(DeltaR);
+      pair.push_back(mll);
+      line.push_back(pair);
+
+    }
+    result.push_back(line);
   }
   return result;
 }
 
-// Match L1Mu to TrigObj
+// Match offline object to TrigObj
 
 vector<int> MatchObjToTrig(ROOT::VecOps::RVec<float>Obj_eta, ROOT::VecOps::RVec<float>Obj_phi, ROOT::VecOps::RVec<float>TrigObj_pt, ROOT::VecOps::RVec<float>TrigObj_eta, ROOT::VecOps::RVec<float>TrigObj_phi, ROOT::VecOps::RVec<int>TrigObj_id, int Target_id, ROOT::VecOps::RVec<int>filterBits){
 
   vector <int> result={};
   for(unsigned int i = 0; i<Obj_eta.size(); i++){
-    //double drmin = 0.4; 
-    double drmin = 0.6; 
+    //For HLT-reco matching => can use a small dR cone size. A larger cone size would be needed for L1-reco matching with muons. 
+    double drmin = 0.2; 
     int idx = -1;
-    //vector<int> idx = {};
-    //vector<double> dr_vec = {};
-
     for(unsigned int j = 0; j<TrigObj_eta.size(); j++){
       if (TrigObj_id[j] != Target_id) continue;
 
@@ -434,14 +370,12 @@ vector<int> MatchObjToTrig(ROOT::VecOps::RVec<float>Obj_eta, ROOT::VecOps::RVec<
       double dphi = abs(acos(cos(TrigObj_phi[j]-Obj_phi[i]))); 
       double dr = sqrt(deta*deta+dphi*dphi);
       if(dr<=drmin){ 
-          if((filterBits[j]>>1&1) == 1){
-             drmin = dr; 
-             idx = j;
-          }
+	if((filterBits[j]>>1&1) == 1){
+	  drmin = dr; 
+	  idx = j;
+	}
       }
     }
-
-    
     result.push_back(idx);
   }
   return result;
@@ -459,4 +393,40 @@ ROOT::VecOps::RVec <Bool_t> trig_is_filterbit1_set(ROOT::VecOps::RVec<int>Trig_i
         }
     }
     return result;
+}
+
+
+ROOT::VecOps::RVec <Bool_t> IsCleanJet(ROOT::VecOps::RVec<float>Obj_pt,  ROOT::VecOps::RVec<float>Obj_eta, ROOT::VecOps::RVec<float>Obj_phi, 
+				       ROOT::VecOps::RVec<float>Lepton_pt, ROOT::VecOps::RVec<float>Lepton_eta, ROOT::VecOps::RVec<float>Lepton_phi, ROOT::VecOps::RVec<int>Lepton_passid,
+				       ROOT::VecOps::RVec<float>Photon_pt, ROOT::VecOps::RVec<float>Photon_eta, ROOT::VecOps::RVec<float>Photon_phi, ROOT::VecOps::RVec<int>Photon_passid ){
+
+  vector <bool> result={};
+  for(unsigned int i = 0; i<Obj_eta.size(); i++){
+    result.push_back(true);
+    double drmin = 0.4; 
+  
+    for(unsigned int j = 0; j<Lepton_eta.size(); j++){
+      if (! Lepton_passid[j] || Lepton_pt[j]<10  ) continue;
+      double deta = abs(Lepton_eta[j]-Obj_eta[i]);
+      double dphi = abs(acos(cos(Lepton_phi[j]-Obj_phi[i]))); 
+      double dr = sqrt(deta*deta+dphi*dphi);
+      if(dr<=drmin){
+	result[i] =false;
+	break;
+      }
+    }
+
+    for(unsigned int j = 0; j<Photon_eta.size(); j++){
+      if (! Photon_passid[j] || Photon_pt[j]<20  ) continue;
+      double deta = abs(Photon_eta[j]-Obj_eta[i]);
+      double dphi = abs(acos(cos(Photon_phi[j]-Obj_phi[i]))); 
+      double dr = sqrt(deta*deta+dphi*dphi);
+      if(dr<=drmin){
+	result[i] =false;
+	break;
+      }
+    }
+  }
+
+  return result;
 }

--- a/helpers/Helper_InvariantMass.h
+++ b/helpers/Helper_InvariantMass.h
@@ -36,6 +36,7 @@ bool PassDiJet140_70_Mjj900(ROOT::VecOps::RVec<float>pt, ROOT::VecOps::RVec<floa
     if(pt[i]<140)continue;
     for(unsigned int j = 0; j<pt.size(); j++){
       if(eta[i]*eta[j]>0) continue;
+      if(abs(eta[i]-eta[j])<2.7) continue;
       if(pt[j]<70)continue;
       TLorentzVector jet1, jet2;
       jet1.SetPtEtaPhiM(pt[i], eta[i], phi[i], 0.);

--- a/helpers/bins.py
+++ b/helpers/bins.py
@@ -6,7 +6,7 @@ muEtaBins = [0., 0.83, 1.24, 2.4]
 muEMTFBins = [1.24, 1.6, 2.1, 2.4]
 
 
-ht_bins = array('f', [ i*10 for i in range(50) ] + [ 500+ i*20 for i in range(25) ] + [1000 + i*50 for i in range(10)] +[1500,1600,1700,1800,2000,2500,3000])
+ht_bins = array('f', [ i*10 for i in range(50) ] + [ 500+ i*20 for i in range(25) ] + [1000 + i*50 for i in range(10)] +[1500,1600,1700,1800,2000,2500,3000,4000,6000,8000])
 #leptonpt_bins = array('f',[ i for i in range(50) ] + [ 50+2*i for i in range(10) ] + [ 70+3*i for i in range(10) ] + [100+10*i for i in range(10) ] + [200, 250, 300, 400, 500])
 jetmetpt_bins = array('f',[ i*5 for i in range(50) ] +  [250+10*i for i in range(25) ]  + [500+20*i for i in range(10) ] + [700, 800, 900, 1000, 1200, 1500, 2000 ])
 

--- a/helpers/bins.py
+++ b/helpers/bins.py
@@ -11,8 +11,7 @@ ht_bins = array('f', [ i*10 for i in range(50) ] + [ 500+ i*20 for i in range(25
 jetmetpt_bins = array('f',[ i*5 for i in range(50) ] +  [250+10*i for i in range(25) ]  + [500+20*i for i in range(10) ] + [700, 800, 900, 1000, 1200, 1500, 2000 ])
 
 # Finer binning:
-#leptonpt_bins = array('f',[i * .2 for i in range(15 * 5)] + [ 15 + i * .5 for i in range(5 * 2)] + [20 + i for i in range(30)] + [ 50+2*i for i in range(10) ] + [ 70+3*i for i in range(10) ] + [100+10*i for i in range(10) ] + [200, 250, 300, 400, 500])
-leptonpt_bins = array('f',[i * .2 for i in range(15 * 5)] + [ 15 + i * .5 for i in range(5 * 2)] + [20 + i for i in range(30)] + [ 50+2*i for i in range(10) ] + [ 70+3*i for i in range(10) ] + [100+10*i for i in range(10) ] + [200, 250, 300, 500, 1000])
+leptonpt_bins = array('f',[i * .2 for i in range(15 * 5)] + [ 15 + i * .5 for i in range(5 * 2)] + [20 + i for i in range(30)] + [ 50+2*i for i in range(10) ] + [ 70+3*i for i in range(10) ] + [100+10*i for i in range(10) ] + [200, 250, 300, 400, 500])
 
 coarse_leptonpt_bins = array('f',[ i for i in range(50) ] + [ 50+2*i for i in range(10) ] + [ 70+3*i for i in range(10) ] + [100+10*i for i in range(10) ] + [200, 250, 300, 400, 500])
 coarse2_leptonpt_bins = array('f',[ i for i in range(20) ] + [20, 25, 30, 35, 45, 60, 75, 100, 140, 200, 250, 300, 400, 500])

--- a/helpers/helper.py
+++ b/helpers/helper.py
@@ -451,12 +451,12 @@ def ZMuMu_Plots(df, suffix = ''):
 
             #
 
-            histos['L1Mu22_FirstBunchInTrain_bx0_etaphi'+suffix] = df_mu[i].Filter("_runNb>=361468").Filter("passL1_Initial_bx0[473]").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_FirstBunchInTrain_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bx0_Eta', 'probeL1Mu22Bx0_Phi')
-            histos['L1Mu22_FirstBunchInTrain_bx0_eta'+suffix] = df_mu[i].Filter("_runNb>=361468").Filter("passL1_Initial_bx0[473]").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_FirstBunchInTrain_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bx0_Eta') 
+            histos['L1Mu22_FirstBunchInTrain_bx0_etaphi'+suffix] = df_mu[i].Filter("passL1_Final_bxmin1[472]").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_FirstBunchInTrain_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bx0_Eta', 'probeL1Mu22Bx0_Phi')
+            histos['L1Mu22_FirstBunchInTrain_bx0_eta'+suffix] = df_mu[i].Filter("passL1_Final_bxmin1[472]").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_FirstBunchInTrain_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bx0_Eta') 
 
-            histos['L1Mu22_FirstBunchInTrain_bxmin1_etaphi'+suffix] = df_mu[i].Filter("_runNb>=361468").Filter("passL1_Initial_bx0[473]").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_FirstBunchInTrain_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bxmin1_Eta', 'probeL1Mu22Bxmin1_Phi')
+            histos['L1Mu22_FirstBunchInTrain_bxmin1_etaphi'+suffix] = df_mu[i].Filter("passL1_Final_bxmin1[472]").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_FirstBunchInTrain_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bxmin1_Eta', 'probeL1Mu22Bxmin1_Phi')
 
-            histos['L1Mu22_FirstBunchInTrain_bxmin1_eta'+suffix] = df_mu[i].Filter("_runNb>=361468").Filter("passL1_Initial_bx0[473]").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_FirstBunchInTrain_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bxmin1_Eta') 
+            histos['L1Mu22_FirstBunchInTrain_bxmin1_eta'+suffix] = df_mu[i].Filter("passL1_Final_bxmin1[472]").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_FirstBunchInTrain_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bxmin1_Eta') 
 
             ###
 
@@ -488,10 +488,14 @@ def ZMuMu_Plots(df, suffix = ''):
 
 def CleanJets(df):
     #List of cleaned jets (noise cleaning + lepton/photon overlap removal)
-    df = df.Define('isCleanJet','_puppijetPassID&&_puppijetLeptonPhotonCleaned&&_puppijetPt>30')
+    
+    #df = df.Define('isCleanJet','_puppijetPassID&&_puppijetLeptonPhotonCleaned&&_puppijetPt>30')
+    df = df.Define('isCleanJet','IsCleanJet(_puppijetPt, _puppijetEta, _puppijetPhi, _lPt, _lEta, _lPhi, _lPassVetoID,  _phPt, _phEta, _phPhi, _phPassIso)')
+    #df = df.Define('isCleanJet','_puppijetPassID&&_puppijetPt>30')
     df = df.Define('cleanJet_Pt','_puppijetPt[isCleanJet]')
     df = df.Define('cleanJet_Eta','_puppijetEta[isCleanJet]')
     df = df.Define('cleanJet_Phi','_puppijetPhi[isCleanJet]')
+
     '''
     df = df.Define('isCleanJet','_jetPassID&&_jetLeptonPhotonCleaned&&_jetPt>30&&_jet_MUEF<0.5&&_jet_CEEF<0.5')
     df = df.Define('cleanJet_Pt','_jetPt[isCleanJet]')
@@ -502,7 +506,7 @@ def CleanJets(df):
     df = df.Define('cleanJet_CHEF','_jet_CHEF[isCleanJet]')
     df = df.Define('cleanJet_CEEF','_jet_CEEF[isCleanJet]')
     df = df.Define('cleanJet_MUEF','_jet_MUEF[isCleanJet]')
-    df = df.Filter(stringToPrintJets)
+    #df = df.Filter(stringToPrintJets)
     '''
     df = df.Filter('Sum(isCleanJet)>=1','>=1 clean jet with p_{T}>30 GeV')
 
@@ -613,14 +617,21 @@ def AnalyzeCleanJets(df, JetRecoPtCut, L1JetPtCut, suffix = ''):
     #Find L1 jets matched to the offline jet
     #df = df.Define('cleanJet_idxL1jet','FindL1ObjIdx(_L1jet_eta, _L1jet_phi, cleanJet_Eta, cleanJet_Phi)')
     # only take jets in bx 0
-    df = df.Define('cleanJet_idxL1jet', 'FindL1ObjIdx_setBx(_L1jet_eta, _L1jet_phi, _L1jet_bx, cleanJet_Eta, cleanJet_Phi, 0)')
-    df = df.Define('cleanJet_L1Pt','GetVal(cleanJet_idxL1jet,_L1jet_pt)')
-    df = df.Define('cleanJet_L1Bx','GetVal(cleanJet_idxL1jet,_L1jet_bx)')
+    df = df.Define('cleanJet_idxL1jetbx0', 'FindL1ObjIdx_setBx(_L1jet_eta, _L1jet_phi, _L1jet_bx, cleanJet_Eta, cleanJet_Phi, 0)')
+    #Select L1 jets in bx+/-1
+    df = df.Define('cleanJet_idxL1jetbxmin1', 'FindL1ObjIdx_setBx(_L1jet_eta, _L1jet_phi, _L1jet_bx, cleanJet_Eta, cleanJet_Phi, -1)')
+    df = df.Define('cleanJet_idxL1jetbx1', 'FindL1ObjIdx_setBx(_L1jet_eta, _L1jet_phi, _L1jet_bx, cleanJet_Eta, cleanJet_Phi, 1)')
+    
+    
+    df = df.Define('cleanJet_L1Pt','GetVal(cleanJet_idxL1jetbx0,_L1jet_pt)')
     df = df.Define('cleanJet_L1PtoverRecoPt','cleanJet_L1Pt/cleanJet_Pt')
+
+    df = df.Define('cleanJet_L1Ptbxmin1','GetVal(cleanJet_idxL1jetbxmin1,_L1jet_pt)')
+    df = df.Define('cleanJet_L1Ptbx1','GetVal(cleanJet_idxL1jetbx1,_L1jet_pt)')
     #df = df.Filter(stringFailingJets)
     ##Now some plotting (turn ons for now)
     L1PtCuts = [30., 40., 60., 80., 100., 120., 140., 160., 170., 180., 200.]
-
+    
 
     df = makehistosforturnons_inprobeetaranges(df, histos, etavarname='cleanJet_Eta', phivarname='cleanJet_Phi', ptvarname='cleanJet_Pt', responsevarname='cleanJet_L1PtoverRecoPt', etabins=jetEtaBins, l1varname='cleanJet_L1Pt', l1thresholds=L1PtCuts, prefix="Jet_plots", binning=jetmetpt_bins, l1thresholdforeffvsrunnb = L1JetPtCut, offlinethresholdforeffvsrunnb = JetRecoPtCut, suffix = suffix) 
 
@@ -636,22 +647,117 @@ def AnalyzeCleanJets(df, JetRecoPtCut, L1JetPtCut, suffix = ''):
     histos["L1JetvsEtaPhi_Numerator"+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('h_L1Jet{}vsEtaPhi_Numerator'.format(int(L1JetPtCut))+suffix, '', 100,-5,5,100,-3.1416,3.1416), 'cleanHighPtJet_Eta_PassL1Jet','cleanHighPtJet_Phi_PassL1Jet')
     histos["L1JetvsEtaPhi_EtaRestricted"+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('h_L1Jet{}vsEtaPhi_EtaRestricted'.format(int(L1JetPtCut))+suffix, '', 100,-5,5,100,-3.1416,3.1416), 'cleanHighPtJet_Eta','cleanHighPtJet_Phi')
     
+    df = df.Define('probe_cleanJet_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000]')
+    df = df.Define('probe_cleanJet_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000]')
+    df = df.Define('probe_cleanJet_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000]')
+
+    L1Ptjetrange = ['50', '150']
+    L1Ptcut = '&&cleanJet_L1Ptbxmin1>'+L1Ptjetrange[0]+'&&cleanJet_L1Ptbxmin1<='+L1Ptjetrange[1]
+    df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bxmin1_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bxmin1_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bxmin1_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+
+    L1Ptcut = '&&cleanJet_L1Pt>'+L1Ptjetrange[0]+'&&cleanJet_L1Pt<='+L1Ptjetrange[1]
+    df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bx0_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bx0_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bx0_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    
+    L1Ptcut = '&&cleanJet_L1Ptbx1>'+L1Ptjetrange[0]+'&&cleanJet_L1Ptbx1<='+L1Ptjetrange[1]
+    df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bxplus1_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bxplus1_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bxplus1_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')    
 
 
-    df = df.Define('probeL1Jet100to150Bxmin1_Eta','cleanJet_Eta[cleanJet_Pt>90&&cleanJet_Pt<160&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150&&cleanJet_L1Bx==-1]')
-    df = df.Define('probeL1Jet100to150Bxmin1_Phi','cleanJet_Phi[cleanJet_Pt>90&&cleanJet_Pt<160&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150&&cleanJet_L1Bx==-1]')
-    df = df.Define('probeL1Jet100to150Bx0_Eta','cleanJet_Eta[cleanJet_Pt>90&&cleanJet_Pt<160&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150&&cleanJet_L1Bx==0]')
-    df = df.Define('probeL1Jet100to150Bx0_Phi','cleanJet_Phi[cleanJet_Pt>90&&cleanJet_Pt<160&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150&&cleanJet_L1Bx==0]')
-    df = df.Define('probeL1Jet100to150Bxplus1_Eta','cleanJet_Eta[cleanJet_Pt>90&&cleanJet_Pt<160&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150&&cleanJet_L1Bx==1]')
-    df = df.Define('probeL1Jet100to150Bxplus1_Phi','cleanJet_Phi[cleanJet_Pt>90&&cleanJet_Pt<160&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150&&cleanJet_L1Bx==1]')
+    L1Ptcut = '&&cleanJet_L1Ptbxmin1>180'
+    df = df.Define('probeL1Jet180Bxmin1_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    df = df.Define('probeL1Jet180Bxmin1_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    df = df.Define('probeL1Jet180Bxmin1_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
 
-    histos['L1Jet100to150_bxmin1_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('L1Jet100to150_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet100to150Bxmin1_Eta', 'probeL1Jet100to150Bxmin1_Phi')
-    histos['L1Jet100to150_bx0_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('L1Jet100to150_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet100to150Bx0_Eta', 'probeL1Jet100to150Bx0_Phi')
-    histos['L1Jet100to150_bxplus1_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('L1Jet100to150_bxplus1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet100to150Bxplus1_Eta', 'probeL1Jet100to150Bxplus1_Phi')
+    L1Ptcut = '&&cleanJet_L1Pt>'+L1Ptjetrange[0]+'&&cleanJet_L1Pt<='+L1Ptjetrange[1]
+    df = df.Define('probeL1Jet180Bx0_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    df = df.Define('probeL1Jet180Bx0_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    df = df.Define('probeL1Jet180Bx0_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
 
-    histos['L1Jet100to150_bxmin1_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel('L1Jet100to150_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1Jet100to150Bxmin1_Eta')
-    histos['L1Jet100to150_bx0_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel('L1Jet100to150_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1Jet100to150Bx0_Eta')
-    histos['L1Jet100to150_bxplus1_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel('L1Jet100to150_bxplus1_eta'+suffix, '', 100, -5, 5), 'probeL1Jet100to150Bxplus1_Eta')
+    L1Ptcut = '&&cleanJet_L1Ptbx1>'+L1Ptjetrange[0]+'&&cleanJet_L1Ptbx1<='+L1Ptjetrange[1]
+    df = df.Define('probeL1Jet180Bxplus1_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    df = df.Define('probeL1Jet180Bxplus1_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    df = df.Define('probeL1Jet180Bxplus1_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+
+    '''
+    df = df.Define('probeL1Jet180Bxmin1_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<160'+'&&'+L1Ptcut+'&&cleanJet_L1Bx==-1]')
+    df = df.Define('probeL1Jet180Bxmin1_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<160'+'&&'+L1Ptcut+'&&cleanJet_L1Bx==-1]')
+    df = df.Define('probeL1Jet180Bx0_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<160'+'&&'+L1Ptcut+'&&cleanJet_L1Bx==0]')
+    df = df.Define('probeL1Jet180Bx0_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<160'+'&&'+L1Ptcut+'&&cleanJet_L1Bx==0]')
+    df = df.Define('probeL1Jet180Bxplus1_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<160'+'&&'+L1Ptcut+'&&cleanJet_L1Bx==1]')
+    df = df.Define('probeL1Jet180Bxplus1_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<160'+'&&'+L1Ptcut+'&&cleanJet_L1Bx==1]')
+    '''
+
+    #For study of SingleJet100-150, we can use all events
+    theprefix = 'L1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]
+    probejetprefix = 'probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]
+    histos['AllEvts_probe_cleanJet_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('AllEvts_probe_cleanJet_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probe_cleanJet_Eta', 'probe_cleanJet_Phi')
+    histos[theprefix+'_bxmin1_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel(theprefix+'_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), probejetprefix+'Bxmin1_Eta', probejetprefix+'Bxmin1_Phi')
+    histos[theprefix+'_bx0_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel(theprefix+'_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), probejetprefix+'Bx0_Eta', probejetprefix+'Bx0_Phi')
+    histos[theprefix+'_bxplus1_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel(theprefix+'_bxplus1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), probejetprefix+'Bxplus1_Eta', probejetprefix+'Bxplus1_Phi')
+
+    histos['AllEvts_probe_cleanJet_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel('AllEvts_probe_cleanJet_eta'+suffix, '', 100, -5, 5), 'probe_cleanJet_Eta')
+    histos[theprefix+'_bxmin1_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel(theprefix+'_bxmin1_eta'+suffix, '', 100, -5, 5), probejetprefix+'Bxmin1_Eta')
+    histos[theprefix+'_bx0_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel(theprefix+'_bx0_eta'+suffix, '', 100, -5, 5), probejetprefix+'Bx0_Eta')
+    histos[theprefix+'_bxplus1_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel(theprefix+'_bxplus1_eta'+suffix, '', 100, -5, 5), probejetprefix+'Bxplus1_Eta')
+    
+    histos['AllEvts_probe_cleanJet_etapt'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('AllEvts_probe_cleanJet_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'probe_cleanJet_Eta', 'probe_cleanJet_Pt')
+    histos[theprefix+'_bxmin1_etapt'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel(theprefix+'_bxmin1_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), probejetprefix+'Bxmin1_Eta', probejetprefix+'Bxmin1_Pt')
+    histos[theprefix+'_bx0_etapt'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel(theprefix+'_bx0_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), probejetprefix+'Bx0_Eta', probejetprefix+'Bx0_Pt')
+    histos[theprefix+'_bxplus1_etapt'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel(theprefix+'_bxplus1_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), probejetprefix+'Bxplus1_Eta', probejetprefix+'Bxplus1_Pt')
+
+
+
+    #For study of SingleJet180, we need unprefirable events only 
+    filterunprefevents = 'passL1_Final_bxmin1[472]||Flag_IsUnprefirable'
+    df_unpref = df.Filter(filterunprefevents)
+    #Add a global denominator (no matching condition to a L1 jet)
+    histos['Unpref_probe_cleanJet_etaphi'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('Unpref_probe_cleanJet_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probe_cleanJet_Eta', 'probe_cleanJet_Phi')
+    histos['L1Jet180_bxmin1_etaphi'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('L1Jet180_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet180Bxmin1_Eta', 'probeL1Jet180Bxmin1_Phi')
+    histos['L1Jet180_bx0_etaphi'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('L1Jet180_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet180Bx0_Eta', 'probeL1Jet180Bx0_Phi')
+    histos['L1Jet180_bxplus1_etaphi'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('L1Jet180_bxplus1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet180Bxplus1_Eta', 'probeL1Jet180Bxplus1_Phi')
+
+    histos['Unpref_probe_cleanJet_eta'+suffix] = df_unpref.Histo1D(ROOT.RDF.TH1DModel('Unpref_probe_cleanJet_eta'+suffix, '', 100, -5, 5), 'probe_cleanJet_Eta')
+    histos['L1Jet180_bxmin1_eta'+suffix] = df_unpref.Histo1D(ROOT.RDF.TH1DModel('L1Jet180_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1Jet180Bxmin1_Eta')
+    histos['L1Jet180_bx0_eta'+suffix] = df_unpref.Histo1D(ROOT.RDF.TH1DModel('L1Jet180_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1Jet180Bx0_Eta')
+    histos['L1Jet180_bxplus1_eta'+suffix] = df_unpref.Histo1D(ROOT.RDF.TH1DModel('L1Jet180_bxplus1_eta'+suffix, '', 100, -5, 5), 'probeL1Jet180Bxplus1_Eta')
+
+    histos['Unpref_probe_cleanJet_etapt'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('Unpref_probe_cleanJet_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'probe_cleanJet_Eta', 'probe_cleanJet_Pt')
+    histos['L1Jet180_bxmin1_etapt'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('L1Jet180_bxmin1_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'probeL1Jet180Bxmin1_Eta', 'probeL1Jet180Bxmin1_Pt')
+    histos['L1Jet180_bx0_etapt'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('L1Jet180_bx0_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'probeL1Jet180Bx0_Eta', 'probeL1Jet180Bx0_Pt')
+    histos['L1Jet180_bxplus1_etapt'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('L1Jet180_bxplus1_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'probeL1Jet180Bxplus1_Eta', 'probeL1Jet180Bxplus1_Pt')
+
+
+
+    #Now taus 
+
+    df = df.Define('_L1isotauer2p1_eta','_L1tau_eta[abs(_L1tau_eta)<2.1&&_L1tau_iso]')
+    df = df.Define('_L1isotauer2p1_pt','_L1tau_pt[abs(_L1tau_eta)<2.1&&_L1tau_iso]')
+    df = df.Define('_L1isotauer2p1_phi','_L1tau_phi[abs(_L1tau_eta)<2.1&&_L1tau_iso]')
+    df = df.Define('_L1isotauer2p1_bx','_L1tau_bx[abs(_L1tau_eta)<2.1&&_L1tau_iso]')
+
+    df = df.Define('cleanJet_idxL1taubx0', 'FindL1ObjIdx_setBx(_L1isotauer2p1_eta, _L1isotauer2p1_phi, _L1isotauer2p1_bx, cleanJet_Eta, cleanJet_Phi, 0)')
+    df = df.Define('cleanJet_idxL1taubxmin1', 'FindL1ObjIdx_setBx(_L1isotauer2p1_eta, _L1isotauer2p1_phi, _L1isotauer2p1_bx, cleanJet_Eta, cleanJet_Phi, -1)')
+    df = df.Define('cleanJet_idxL1taubx1', 'FindL1ObjIdx_setBx(_L1isotauer2p1_eta, _L1isotauer2p1_phi, _L1isotauer2p1_bx, cleanJet_Eta, cleanJet_Phi, 1)')
+    
+    df = df.Define('cleanJet_L1tauPt','GetVal(cleanJet_idxL1taubx0,_L1tau_pt)')
+    df = df.Define('cleanJet_L1tauPtbxmin1','GetVal(cleanJet_idxL1taubxmin1,_L1tau_pt)')
+    df = df.Define('cleanJet_L1tauPtbx1','GetVal(cleanJet_idxL1taubx1,_L1tau_pt)')
+    
+    L1Ptcut = '&&cleanJet_L1tauPtbxmin1>34'
+    df = df.Define('probeL1isotau34er2p1Bxmin1_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    df = df.Define('probeL1isotau34er2p1Bxmin1_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    df = df.Define('probeL1isotau34er2p1Bxmin1_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+    
+    histos['L1IsoTau34Er2p1_bxmin1_etapt'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('L1IsoTau34Er2p1_bxmin1_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'probeL1isotau34er2p1Bxmin1_Eta', 'probeL1isotau34er2p1Bxmin1_Pt')
+    
+
+
+
 
     return df, histos
 
@@ -717,7 +823,7 @@ def PtBalanceSelection(df):
     #Compute Pt balance = pt(jet)/pt(ref) => here ref is a photon
     #Reco first
     df = df.Define('ptbalance','cleanJet_Pt[0]/ref_Pt')
-    df = df.Define('ptbalanceL1','_L1jet_pt[cleanJet_idxL1jet[0]]/ref_Pt')
+    df = df.Define('ptbalanceL1','_L1jet_pt[cleanJet_idxL1jetbx0[0]]/ref_Pt')
     df = df.Define('probe_Eta','cleanJet_Eta[0]') 
     df = df.Define('probe_Phi','cleanJet_Phi[0]')
     return df

--- a/helpers/helper_nano.py
+++ b/helpers/helper_nano.py
@@ -169,7 +169,7 @@ def SinglePhotonSelection(df):
     df = df.Define('photonsptgt20','Photon_pt>20')
     df = df.Filter('Sum(photonsptgt20)==1','=1 photon with p_{T}>20 GeV')
 
-    df = df.Define('isRefPhoton','Photon_mvaID_WP80&&Photon_pt>115&&abs(Photon_eta)<1.479')
+    df = df.Define('isRefPhoton','Photon_mvaID_WP80&&Photon_electronVeto&&Photon_pt>115&&abs(Photon_eta)<1.479')
     df = df.Filter('Sum(isRefPhoton)==1','Photon has p_{T}>115 GeV, passes tight ID and is in EB')
     
     df = df.Define('cleanPh_Pt','Photon_pt[isRefPhoton]')

--- a/helpers/helper_nano.py
+++ b/helpers/helper_nano.py
@@ -282,6 +282,31 @@ def ZMuMu_MuSelection(df):
 
     return df
 
+def DiJetSelection(df):
+    '''
+    Select events with two jets with pt>500 GeV and mjj>1000 GeV
+    The event must pass a jet trigger. 
+    '''
+
+    df = df.Filter('HLT_AK8PFJet500&&PuppiMET_pt<300')
+    df = df.Define('isHighPtJet','Jet_jetId>=6&&Jet_pt>500&&Jet_muEF<0.5&&Jet_chEmEF<0.5')
+
+    df = df.Filter('Sum(isHighPtJet)>=2','>=2 jets with pt>500 GeV')
+    
+    df = df.Define('highPtJet_Pt','Jet_pt[isHighPtJet]')
+    df = df.Define('highPtJet_Eta','Jet_eta[isHighPtJet]')
+    df = df.Define('highPtJet_Phi','Jet_phi[isHighPtJet]')
+    
+    
+    df = df.Define('_mjj', 'mll(Jet_pt, Jet_eta, Jet_phi, isHighPtJet, isHighPtJet)')
+    df = df.Filter('_mjj>1000')
+
+
+    return df
+
+
+
+
 def makehistosforturnons_inprobeetaranges(df, histos, etavarname, phivarname, ptvarname, responsevarname, l1varname, l1thresholds, prefix, binning, l1thresholdforeffvsrunnb, offlinethresholdforeffvsrunnb, suffix = ''):
     '''Make histos for turnons vs pt (1D histos for numerator and denominator) in ranges of eta
     Also look at response vs run number (2D histo) '''
@@ -409,11 +434,11 @@ def ZEE_Plots(df, suffix = ''):
 
             #
 
-            histos['L1EG30_OR_bxmin1_etaphi'+suffix] = df_eg[i].Filter("L1_UnprefireableEvent||((run>=361468)&L1_FirstBunchInTrain)").Histo2D(ROOT.RDF.TH2DModel('L1EG30_OR_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1EG30Bxmin1_Eta', 'probeL1EG30Bxmin1_Phi')
-            histos['L1EG30_OR_bx0_etaphi'+suffix] = df_eg[i].Filter("L1_UnprefireableEvent||((run>=361468)&L1_FirstBunchInTrain)").Histo2D(ROOT.RDF.TH2DModel('L1EG30_OR_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1EG30Bx0_Eta', 'probeL1EG30Bx0_Phi')
+            histos['L1EG30_OR_bxmin1_etaphi'+suffix] = df_eg[i].Filter("L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain").Histo2D(ROOT.RDF.TH2DModel('L1EG30_OR_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1EG30Bxmin1_Eta', 'probeL1EG30Bxmin1_Phi')
+            histos['L1EG30_OR_bx0_etaphi'+suffix] = df_eg[i].Filter("L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain").Histo2D(ROOT.RDF.TH2DModel('L1EG30_OR_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1EG30Bx0_Eta', 'probeL1EG30Bx0_Phi')
 
-            histos['L1EG30_OR_bxmin1_eta'+suffix] = df_eg[i].Filter("L1_UnprefireableEvent||((run>=361468)&L1_FirstBunchInTrain)").Histo1D(ROOT.RDF.TH1DModel('L1EG30_OR_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1EG30Bxmin1_Eta')
-            histos['L1EG30_OR_bx0_eta'+suffix] = df_eg[i].Filter("L1_UnprefireableEvent||((run>=361468)&L1_FirstBunchInTrain)").Histo1D(ROOT.RDF.TH1DModel('L1EG30_OR_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1EG30Bx0_Eta')
+            histos['L1EG30_OR_bxmin1_eta'+suffix] = df_eg[i].Filter("L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain").Histo1D(ROOT.RDF.TH1DModel('L1EG30_OR_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1EG30Bxmin1_Eta')
+            histos['L1EG30_OR_bx0_eta'+suffix] = df_eg[i].Filter("L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain").Histo1D(ROOT.RDF.TH1DModel('L1EG30_OR_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1EG30Bx0_Eta')
 
     return df, histos
     
@@ -516,28 +541,31 @@ def ZMuMu_Plots(df, suffix = ''):
 
             #
 
-            histos['L1Mu22_IsUnprefireable_bx0_etaphi'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_IsUnprefireable_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bx0_Eta', 'probeL1Mu22Bx0_Phi')
-            histos['L1Mu22_IsUnprefireable_bx0_eta'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_IsUnprefireable_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bx0_Eta') 
+            histos['L1Mu22_IsUnprefireable_bx0_etaphi'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_TriggerRules").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_IsUnprefireable_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bx0_Eta', 'probeL1Mu22Bx0_Phi')
+            histos['L1Mu22_IsUnprefireable_bx0_eta'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_TriggerRules").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_IsUnprefireable_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bx0_Eta') 
 
-            histos['L1Mu22_IsUnprefireable_bxmin1_etaphi'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_IsUnprefireable_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bxmin1_Eta', 'probeL1Mu22Bxmin1_Phi')
-            histos['L1Mu22_IsUnprefireable_bxmin1_eta'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_IsUnprefireable_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bxmin1_Eta') 
+            histos['L1Mu22_IsUnprefireable_bxmin1_etaphi'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_TriggerRules").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_IsUnprefireable_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bxmin1_Eta', 'probeL1Mu22Bxmin1_Phi')
+            histos['L1Mu22_IsUnprefireable_bxmin1_eta'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_TriggerRules").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_IsUnprefireable_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bxmin1_Eta') 
+
+            #
+            
+
+            histos['L1Mu22_FirstBunchInTrain_bx0_etaphi'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_FirstBxInTrain").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_FirstBunchInTrain_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bx0_Eta', 'probeL1Mu22Bx0_Phi')
+            histos['L1Mu22_FirstBunchInTrain_bx0_eta'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_FirstBxInTrain").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_FirstBunchInTrain_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bx0_Eta') 
+            
+
+
+            histos['L1Mu22_FirstBunchInTrain_bxmin1_etaphi'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_FirstBxInTrain").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_FirstBunchInTrain_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bxmin1_Eta', 'probeL1Mu22Bxmin1_Phi')
+
+            histos['L1Mu22_FirstBunchInTrain_bxmin1_eta'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_FirstBxInTrain").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_FirstBunchInTrain_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bxmin1_Eta') 
 
             #
 
-            histos['L1Mu22_FirstBunchInTrain_bx0_etaphi'+suffix] = df_mu[i].Filter("run>=361468").Filter("L1_FirstBunchInTrain").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_FirstBunchInTrain_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bx0_Eta', 'probeL1Mu22Bx0_Phi')
-            histos['L1Mu22_FirstBunchInTrain_bx0_eta'+suffix] = df_mu[i].Filter("run>=361468").Filter("L1_FirstBunchInTrain").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_FirstBunchInTrain_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bx0_Eta') 
+            histos['L1Mu22_OR_bx0_etaphi'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_OR_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bx0_Eta', 'probeL1Mu22Bx0_Phi')
+            histos['L1Mu22_OR_bx0_eta'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_OR_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bx0_Eta') 
 
-            histos['L1Mu22_FirstBunchInTrain_bxmin1_etaphi'+suffix] = df_mu[i].Filter("run>=361468").Filter("L1_FirstBunchInTrain").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_FirstBunchInTrain_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bxmin1_Eta', 'probeL1Mu22Bxmin1_Phi')
-
-            histos['L1Mu22_FirstBunchInTrain_bxmin1_eta'+suffix] = df_mu[i].Filter("run>=361468").Filter("L1_FirstBunchInTrain").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_FirstBunchInTrain_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bxmin1_Eta') 
-
-            #
-
-            histos['L1Mu22_OR_bx0_etaphi'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent||((run>=361468)&L1_FirstBunchInTrain)").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_OR_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bx0_Eta', 'probeL1Mu22Bx0_Phi')
-            histos['L1Mu22_OR_bx0_eta'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent||((run>=361468)&L1_FirstBunchInTrain)").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_OR_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bx0_Eta') 
-
-            histos['L1Mu22_OR_bxmin1_etaphi'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent||((run>=361468)&L1_FirstBunchInTrain)").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_OR_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bxmin1_Eta', 'probeL1Mu22Bxmin1_Phi')
-            histos['L1Mu22_OR_bxmin1_eta'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent||((run>=361468)&L1_FirstBunchInTrain)").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_OR_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bxmin1_Eta') 
+            histos['L1Mu22_OR_bxmin1_etaphi'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain").Histo2D(ROOT.RDF.TH2DModel('L1Mu22_OR_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu22Bxmin1_Eta', 'probeL1Mu22Bxmin1_Phi')
+            histos['L1Mu22_OR_bxmin1_eta'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain").Histo1D(ROOT.RDF.TH1DModel('L1Mu22_OR_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1Mu22Bxmin1_Eta') 
 
             ###
 
@@ -550,11 +578,11 @@ def ZMuMu_Plots(df, suffix = ''):
 
             #
 
-            histos['L1Mu10_OR_bx0_etaphi'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent||((run>=361468)&L1_FirstBunchInTrain)").Histo2D(ROOT.RDF.TH2DModel('L1Mu10_OR_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu10Bx0_Eta', 'probeL1Mu10Bx0_Phi')
-            histos['L1Mu10_OR_bx0_eta'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent||((run>=361468)&L1_FirstBunchInTrain)").Histo1D(ROOT.RDF.TH1DModel('L1Mu10_OR_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1Mu10Bx0_Eta') 
+            histos['L1Mu10_OR_bx0_etaphi'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain").Histo2D(ROOT.RDF.TH2DModel('L1Mu10_OR_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu10Bx0_Eta', 'probeL1Mu10Bx0_Phi')
+            histos['L1Mu10_OR_bx0_eta'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain").Histo1D(ROOT.RDF.TH1DModel('L1Mu10_OR_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1Mu10Bx0_Eta') 
 
-            histos['L1Mu10_OR_bxmin1_etaphi'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent||((run>=361468)&L1_FirstBunchInTrain)").Histo2D(ROOT.RDF.TH2DModel('L1Mu10_OR_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu10Bxmin1_Eta', 'probeL1Mu10Bxmin1_Phi')
-            histos['L1Mu10_OR_bxmin1_eta'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent||((run>=361468)&L1_FirstBunchInTrain)").Histo1D(ROOT.RDF.TH1DModel('L1Mu10_OR_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1Mu10Bxmin1_Eta') 
+            histos['L1Mu10_OR_bxmin1_etaphi'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain").Histo2D(ROOT.RDF.TH2DModel('L1Mu10_OR_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Mu10Bxmin1_Eta', 'probeL1Mu10Bxmin1_Phi')
+            histos['L1Mu10_OR_bxmin1_eta'+suffix] = df_mu[i].Filter("L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain").Histo1D(ROOT.RDF.TH1DModel('L1Mu10_OR_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1Mu10Bxmin1_Eta') 
 
 
             '''
@@ -566,13 +594,13 @@ def ZMuMu_Plots(df, suffix = ''):
             df_mu[i] = df_mu[i].Define('probeEta_L1Mu22_inbxmin1','probe_Eta[probe_Pt>30&&probe_L1Pt_inbxmin1>22]')
             df_mu[i] = df_mu[i].Define('probePhi_L1Mu22_inbxmin1','probe_Phi[probe_Pt>30&&probe_L1Pt_inbxmin1>22]')
 
-            #Next lines are still WIP
-            histos['L1Mu22_denforPrefiring_etaphi'] = df_mu[i].Filter('Flag_IsUnprefirable').Histo2D(ROOT.RDF.TH2DModel('', '', 100, -5,5, 100, -3.1416, 3.1416), 'probePt30PassL1Mu22_Eta', 'probePt30PassL1Mu22_Phi')
-            histos['L1Mu22_numforPrefiring_etaphi'] = df_mu[i].Filter('Flag_IsUnprefirable').Histo2D(ROOT.RDF.TH2DModel('', '', 100, -5,5, 100, -3.1416, 3.1416), 'probeEta_L1Mu22_inbxmin1', 'probePhi_L1Mu22_inbxmin1')
+
             '''
 
     return df, histos
-    
+
+
+
 def CleanJets(df):
     #List of cleaned jets (noise cleaning + lepton/photon overlap removal)
     df = df.Define('_jetPassID', 'Jet_jetId>=4')
@@ -681,10 +709,18 @@ def AnalyzeCleanJets(df, JetRecoPtCut, L1JetPtCut, suffix = ''):
     #Find L1 jets matched to the offline jet
     #df = df.Define('cleanJet_idxL1jet','FindL1JetIdx(L1Jet_eta, L1Jet_phi, cleanJet_Eta, cleanJet_Phi)')
     # only take jets in bx 0
-    df = df.Define('cleanJet_idxL1jet', 'FindL1JetIdx_setBx(L1Jet_eta, L1Jet_phi, L1Jet_bx, cleanJet_Eta, cleanJet_Phi, 0)')
-    df = df.Define('cleanJet_L1Pt','GetVal(cleanJet_idxL1jet,L1Jet_pt)')
-    df = df.Define('cleanJet_L1Bx','GetVal(cleanJet_idxL1jet,L1Jet_bx)')
+
+    df = df.Define('cleanJet_idxL1jetbx0', 'FindL1ObjIdx_setBx(L1Jet_eta, L1Jet_phi, L1Jet_bx, cleanJet_Eta, cleanJet_Phi, 0)')
+    df = df.Define('cleanJet_idxL1jetbxmin1', 'FindL1ObjIdx_setBx(L1Jet_eta, L1Jet_phi, L1Jet_bx, cleanJet_Eta, cleanJet_Phi, -1)')
+    df = df.Define('cleanJet_idxL1jetbx1', 'FindL1ObjIdx_setBx(L1Jet_eta, L1Jet_phi, L1Jet_bx, cleanJet_Eta, cleanJet_Phi, 1)')
+    df = df.Define('cleanJet_L1Pt','GetVal(cleanJet_idxL1jetbx0,L1Jet_pt)')
+
+    df = df.Define('cleanJet_L1Ptbxmin1','GetVal(cleanJet_idxL1jetbxmin1,L1Jet_pt)')
+    df = df.Define('cleanJet_L1Ptbx1','GetVal(cleanJet_idxL1jetbx1,L1Jet_pt)')
+    
     df = df.Define('cleanJet_L1PtoverRecoPt','cleanJet_L1Pt/cleanJet_Pt')
+
+
     df = df.Filter(stringFailingJets)
     #Now some plotting (turn ons for now)
     L1PtCuts = [30., 40., 60., 80., 100., 120., 140., 160., 170., 180., 200.]
@@ -705,43 +741,108 @@ def AnalyzeCleanJets(df, JetRecoPtCut, L1JetPtCut, suffix = ''):
         histos["L1JetvsEtaPhi_EtaRestricted"+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('h_L1Jet{}vsEtaPhi_EtaRestricted'.format(int(L1JetPtCut))+suffix, '', 100,-5,5,100,-3.1416,3.1416), 'cleanHighPtJet_Eta','cleanHighPtJet_Phi')
     
 
+
     if config['Prefiring']:
 
-        df = df.Define('cleanJet_idxL1jet_allBx', 'FindL1JetIdx(L1Jet_eta, L1Jet_phi, cleanJet_Eta, cleanJet_Phi)')
-        df = df.Define('cleanJet_L1Pt_allBx','GetVal(cleanJet_idxL1jet_allBx, L1Jet_pt)')
+        df = df.Define('probe_cleanJet_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000]')
+        df = df.Define('probe_cleanJet_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000]')
+        df = df.Define('probe_cleanJet_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000]')
 
-        df = df.Define('cleanJet_idxL1jet_Bxmin1', 'FindL1JetIdx_setBx(L1Jet_eta, L1Jet_phi, L1Jet_bx, cleanJet_Eta, cleanJet_Phi, -1)')
-        df = df.Define('cleanJet_L1Pt_Bxmin1','GetVal(cleanJet_idxL1jet_Bxmin1, L1Jet_pt)')
+        L1Ptjetrange = ['50', '150']
+        L1Ptcut = '&&cleanJet_L1Ptbxmin1>'+L1Ptjetrange[0]+'&&cleanJet_L1Ptbxmin1<='+L1Ptjetrange[1]
+        df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bxmin1_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bxmin1_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bxmin1_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
 
-        df = df.Define('cleanJet_idxL1jet_Bxplus1', 'FindL1JetIdx_setBx(L1Jet_eta, L1Jet_phi, L1Jet_bx, cleanJet_Eta, cleanJet_Phi, 1)')
-        df = df.Define('cleanJet_L1Pt_Bxplus1','GetVal(cleanJet_idxL1jet_Bxplus1, L1Jet_pt)')
+        L1Ptcut = '&&cleanJet_L1Pt>'+L1Ptjetrange[0]+'&&cleanJet_L1Pt<='+L1Ptjetrange[1]
+        df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bx0_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bx0_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bx0_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
 
-        #
+        L1Ptcut = '&&cleanJet_L1Ptbx1>'+L1Ptjetrange[0]+'&&cleanJet_L1Ptbx1<='+L1Ptjetrange[1]
+        df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bxplus1_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bxplus1_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        df = df.Define('probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]+'Bxplus1_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')    
+        
+        L1Ptcut = '&&cleanJet_L1Ptbxmin1>180'
+        df = df.Define('probeL1Jet180Bxmin1_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        df = df.Define('probeL1Jet180Bxmin1_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        df = df.Define('probeL1Jet180Bxmin1_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        
+        L1Ptcut = '&&cleanJet_L1Pt>'+L1Ptjetrange[0]+'&&cleanJet_L1Pt<='+L1Ptjetrange[1]
+        df = df.Define('probeL1Jet180Bx0_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        df = df.Define('probeL1Jet180Bx0_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        df = df.Define('probeL1Jet180Bx0_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        
+        L1Ptcut = '&&cleanJet_L1Ptbx1>'+L1Ptjetrange[0]+'&&cleanJet_L1Ptbx1<='+L1Ptjetrange[1]
+        df = df.Define('probeL1Jet180Bxplus1_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        df = df.Define('probeL1Jet180Bxplus1_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        df = df.Define('probeL1Jet180Bxplus1_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        
 
-        #df = df.Define('probeL1Jet100to150Bxmin1_Eta','cleanJet_Eta[cleanJet_Pt>90&&cleanJet_Pt<160&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150&&cleanJet_L1Bx==-1]')
-        #df = df.Define('probeL1Jet100to150Bxmin1_Phi','cleanJet_Phi[cleanJet_Pt>90&&cleanJet_Pt<160&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150&&cleanJet_L1Bx==-1]')
-        #df = df.Define('probeL1Jet100to150Bx0_Eta','cleanJet_Eta[cleanJet_Pt>90&&cleanJet_Pt<160&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150&&cleanJet_L1Bx==0]')
-        #df = df.Define('probeL1Jet100to150Bx0_Phi','cleanJet_Phi[cleanJet_Pt>90&&cleanJet_Pt<160&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150&&cleanJet_L1Bx==0]')
-        #df = df.Define('probeL1Jet100to150Bxplus1_Eta','cleanJet_Eta[cleanJet_Pt>90&&cleanJet_Pt<160&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150&&cleanJet_L1Bx==1]')
-        #df = df.Define('probeL1Jet100to150Bxplus1_Phi','cleanJet_Phi[cleanJet_Pt>90&&cleanJet_Pt<160&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150&&cleanJet_L1Bx==1]')
+        #For study of SingleJet100-150, we can use all events
+        theprefix = 'L1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]
+        probejetprefix = 'probeL1Jet'+L1Ptjetrange[0]+'to'+L1Ptjetrange[1]
+        histos['AllEvts_probe_cleanJet_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('AllEvts_probe_cleanJet_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probe_cleanJet_Eta','probe_cleanJet_Phi')
+        histos[theprefix+'_bxmin1_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel(theprefix+'_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), probejetprefix+'Bxmin1_Eta', probejetprefix+'Bxmin1_Phi')
+        histos[theprefix+'_bx0_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel(theprefix+'_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), probejetprefix+'Bx0_Eta', probejetprefix+'Bx0_Phi')
+        histos[theprefix+'_bxplus1_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel(theprefix+'_bxplus1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), probejetprefix+'Bxplus1_Eta',probejetprefix+'Bxplus1_Phi')
 
-        filter_100to150 = 'cleanJet_Pt>90&&cleanJet_Pt<160&&cleanJet_L1Pt_allBx>100&&cleanJet_L1Pt_allBx<=150'
-        df = df.Define('probeL1Jet100to150Bxmin1_Eta','cleanJet_Eta[{}&&cleanJet_L1Pt_Bxmin1>100&&cleanJet_L1Pt_Bxmin1<=150]'.format(filter_100to150))
-        df = df.Define('probeL1Jet100to150Bxmin1_Phi','cleanJet_Phi[{}&&cleanJet_L1Pt_Bxmin1>100&&cleanJet_L1Pt_Bxmin1<=150]'.format(filter_100to150))
-        df = df.Define('probeL1Jet100to150Bx0_Eta','cleanJet_Eta[{}&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150]'.format(filter_100to150))
-        df = df.Define('probeL1Jet100to150Bx0_Phi','cleanJet_Phi[{}&&cleanJet_L1Pt>100&&cleanJet_L1Pt<=150]'.format(filter_100to150))
-        df = df.Define('probeL1Jet100to150Bxplus1_Eta','cleanJet_Eta[{}&&cleanJet_L1Pt_Bxplus1>100&&cleanJet_L1Pt_Bxplus1<=150]'.format(filter_100to150))
-        df = df.Define('probeL1Jet100to150Bxplus1_Phi','cleanJet_Phi[{}&&cleanJet_L1Pt_Bxplus1>100&&cleanJet_L1Pt_Bxplus1<=150]'.format(filter_100to150))
+        histos['AllEvts_probe_cleanJet_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel('AllEvts_probe_cleanJet_eta'+suffix, '', 100, -5, 5), 'probe_cleanJet_Eta')
+        histos[theprefix+'_bxmin1_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel(theprefix+'_bxmin1_eta'+suffix, '', 100, -5, 5), probejetprefix+'Bxmin1_Eta')
+        histos[theprefix+'_bx0_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel(theprefix+'_bx0_eta'+suffix, '', 100, -5, 5), probejetprefix+'Bx0_Eta')
+        histos[theprefix+'_bxplus1_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel(theprefix+'_bxplus1_eta'+suffix, '', 100, -5, 5), probejetprefix+'Bxplus1_Eta')
+        
+        histos['AllEvts_probe_cleanJet_etapt'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('AllEvts_probe_cleanJet_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'probe_cleanJet_Eta', 'probe_cleanJet_Pt')
+        histos[theprefix+'_bxmin1_etapt'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel(theprefix+'_bxmin1_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), probejetprefix+'Bxmin1_Eta', probejetprefix+'Bxmin1_Pt')
+        histos[theprefix+'_bx0_etapt'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel(theprefix+'_bx0_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), probejetprefix+'Bx0_Eta', probejetprefix+'Bx0_Pt')
+        histos[theprefix+'_bxplus1_etapt'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel(theprefix+'_bxplus1_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), probejetprefix+'Bxplus1_Eta', probejetprefix+'Bxplus1_Pt')
+        
+        
+        #For study of SingleJet180, we need unprefirable events only
+        filterunprefevents = 'L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain'
+        df_unpref = df.Filter(filterunprefevents)
+        #Add a global denominator (no matching condition to a L1 jet)   
+        histos['Unpref_probe_cleanJet_etaphi'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('Unpref_probe_cleanJet_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probe_cleanJet_Eta', 'probe_cleanJet_Phi')
+        histos['L1Jet180_bxmin1_etaphi'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('L1Jet180_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet180Bxmin1_Eta', 'probeL1Jet180Bxmin1_Phi')
+        histos['L1Jet180_bx0_etaphi'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('L1Jet180_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet180Bx0_Eta', 'probeL1Jet180Bx0_Phi')
+        histos['L1Jet180_bxplus1_etaphi'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('L1Jet180_bxplus1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet180Bxplus1_Eta', 'probeL1Jet180Bxplus1_Phi')
+        
+        histos['Unpref_probe_cleanJet_eta'+suffix] = df_unpref.Histo1D(ROOT.RDF.TH1DModel('Unpref_probe_cleanJet_eta'+suffix, '', 100, -5, 5), 'probe_cleanJet_Eta')
+        histos['L1Jet180_bxmin1_eta'+suffix] = df_unpref.Histo1D(ROOT.RDF.TH1DModel('L1Jet180_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1Jet180Bxmin1_Eta')
+        histos['L1Jet180_bx0_eta'+suffix] = df_unpref.Histo1D(ROOT.RDF.TH1DModel('L1Jet180_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1Jet180Bx0_Eta')
+        histos['L1Jet180_bxplus1_eta'+suffix] = df_unpref.Histo1D(ROOT.RDF.TH1DModel('L1Jet180_bxplus1_eta'+suffix, '', 100, -5, 5), 'probeL1Jet180Bxplus1_Eta')
+        
+        histos['Unpref_probe_cleanJet_etapt'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('Unpref_probe_cleanJet_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'probe_cleanJet_Eta', 'probe_cleanJet_Pt')
+        histos['L1Jet180_bxmin1_etapt'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('L1Jet180_bxmin1_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'probeL1Jet180Bxmin1_Eta', 'probeL1Jet180Bxmin1_Pt')
+        histos['L1Jet180_bx0_etapt'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('L1Jet180_bx0_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'probeL1Jet180Bx0_Eta', 'probeL1Jet180Bx0_Pt')
+        histos['L1Jet180_bxplus1_etapt'+suffix] = df_unpref.Histo2D(ROOT.RDF.TH2DModel('L1Jet180_bxplus1_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'probeL1Jet180Bxplus1_Eta', 'probeL1Jet180Bxplus1_Pt')
+        
+        #Now taus 
+        
+        df = df.Define('_L1isotauer2p1_eta','L1Tau_eta[abs(L1Tau_eta)<2.1&&L1Tau_hwIso>=1]')
+        df = df.Define('_L1isotauer2p1_pt','L1Tau_pt[abs(L1Tau_eta)<2.1&&L1Tau_hwIso>=1]')
+        df = df.Define('_L1isotauer2p1_phi','L1Tau_phi[abs(L1Tau_eta)<2.1&&L1Tau_hwIso>=1]')
+        df = df.Define('_L1isotauer2p1_bx','L1Tau_bx[abs(L1Tau_eta)<2.1&&L1Tau_hwIso>=1]')
+        
+        df = df.Define('cleanJet_idxL1taubx0', 'FindL1ObjIdx_setBx(_L1isotauer2p1_eta, _L1isotauer2p1_phi, _L1isotauer2p1_bx, cleanJet_Eta, cleanJet_Phi, 0)')
+        df = df.Define('cleanJet_idxL1taubxmin1', 'FindL1ObjIdx_setBx(_L1isotauer2p1_eta, _L1isotauer2p1_phi, _L1isotauer2p1_bx, cleanJet_Eta, cleanJet_Phi, -1)')
+        df = df.Define('cleanJet_idxL1taubx1', 'FindL1ObjIdx_setBx(_L1isotauer2p1_eta, _L1isotauer2p1_phi, _L1isotauer2p1_bx, cleanJet_Eta, cleanJet_Phi, 1)')
+        
+        df = df.Define('cleanJetL1TauPt','GetVal(cleanJet_idxL1taubx0,L1Tau_pt)')
+        df = df.Define('cleanJetL1TauPtbxmin1','GetVal(cleanJet_idxL1taubxmin1,L1Tau_pt)')
+        df = df.Define('cleanJetL1TauPtbx1','GetVal(cleanJet_idxL1taubx1,L1Tau_pt)')
+        
+        L1Ptcut = '&&cleanJetL1TauPtbxmin1>34'
+        df = df.Define('probeL1isotau34er2p1Bxmin1_Eta','cleanJet_Eta[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        df = df.Define('probeL1isotau34er2p1Bxmin1_Phi','cleanJet_Phi[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        df = df.Define('probeL1isotau34er2p1Bxmin1_Pt','cleanJet_Pt[cleanJet_Pt>100&&cleanJet_Pt<16000'+L1Ptcut+']')
+        
+        histos['L1IsoTau34Er2p1_bxmin1_etapt'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('L1IsoTau34Er2p1_bxmin1_etapt'+suffix, '', 100, -5,5, len(jetmetpt_bins)-1, array('d',jetmetpt_bins)), 'probeL1isotau34er2p1Bxmin1_Eta', 'probeL1isotau34er2p1Bxmin1_Pt')
 
 
 
-        histos['L1Jet100to150_bxmin1_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('L1Jet100to150_bxmin1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet100to150Bxmin1_Eta', 'probeL1Jet100to150Bxmin1_Phi')
-        histos['L1Jet100to150_bx0_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('L1Jet100to150_bx0_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet100to150Bx0_Eta', 'probeL1Jet100to150Bx0_Phi')
-        histos['L1Jet100to150_bxplus1_etaphi'+suffix] = df.Histo2D(ROOT.RDF.TH2DModel('L1Jet100to150_bxplus1_etaphi'+suffix, '', 100, -5,5, 100, -3.1416, 3.1416), 'probeL1Jet100to150Bxplus1_Eta', 'probeL1Jet100to150Bxplus1_Phi')
 
-        histos['L1Jet100to150_bxmin1_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel('L1Jet100to150_bxmin1_eta'+suffix, '', 100, -5, 5), 'probeL1Jet100to150Bxmin1_Eta')
-        histos['L1Jet100to150_bx0_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel('L1Jet100to150_bx0_eta'+suffix, '', 100, -5, 5), 'probeL1Jet100to150Bx0_Eta')
-        histos['L1Jet100to150_bxplus1_eta'+suffix] = df.Histo1D(ROOT.RDF.TH1DModel('L1Jet100to150_bxplus1_eta'+suffix, '', 100, -5, 5), 'probeL1Jet100to150Bxplus1_Eta')
 
     return df, histos
 
@@ -803,7 +904,7 @@ def PtBalanceSelection(df):
     #Compute Pt balance = pt(jet)/pt(ref) => here ref is a photon
     #Reco first
     df = df.Define('ptbalance','cleanJet_Pt[0]/ref_Pt')
-    df = df.Define('ptbalanceL1','L1Jet_pt[cleanJet_idxL1jet[0]]/ref_Pt')
+    df = df.Define('ptbalanceL1','L1Jet_pt[cleanJet_idxL1jetbx0[0]]/ref_Pt')
     df = df.Define('probe_Eta','cleanJet_Eta[0]') 
     df = df.Define('probe_Phi','cleanJet_Phi[0]')
     return df

--- a/helpers/helper_nano.py
+++ b/helpers/helper_nano.py
@@ -364,10 +364,10 @@ def ZEE_Plots(df, suffix = ''):
 
     for i, iso in enumerate(config['Isos']):
         
-        df_eg[i] = df.Define('probe_idxL1EG','FindL1EGIdx(L1EG_eta, L1EG_phi, probe_Eta, probe_Phi, probe_Pt, L1EG_hwIso, {})'.format(config['Isos'][iso]))
-        df_eg[i] = df_eg[i].Define('probe_idxL1EG_Bx0','FindL1EGIdx_setBx(L1EG_eta, L1EG_phi, L1EG_bx, probe_Eta, probe_Phi, probe_Pt, 0, L1EG_hwIso, {})'.format(config['Isos'][iso]))
-        df_eg[i] = df_eg[i].Define('probe_idxL1EG_Bxmin1','FindL1EGIdx_setBx(L1EG_eta, L1EG_phi, L1EG_bx, probe_Eta, probe_Phi, probe_Pt, -1, L1EG_hwIso, {})'.format(config['Isos'][iso]))
-        df_eg[i] = df_eg[i].Define('probe_idxL1EG_Bxplus1','FindL1EGIdx_setBx(L1EG_eta, L1EG_phi, L1EG_bx, probe_Eta, probe_Phi, probe_Pt, 1, L1EG_hwIso, {})'.format(config['Isos'][iso]))
+        df_eg[i] = df.Define('probe_idxL1EG','FindL1ObjIdx(L1EG_eta, L1EG_phi, probe_Eta, probe_Phi, L1EG_hwIso, {})'.format(config['Isos'][iso]))
+        df_eg[i] = df_eg[i].Define('probe_idxL1EG_Bx0','FindL1ObjIdx_setBx(L1EG_eta, L1EG_phi, L1EG_bx, probe_Eta, probe_Phi, 0, L1EG_hwIso, {})'.format(config['Isos'][iso]))
+        df_eg[i] = df_eg[i].Define('probe_idxL1EG_Bxmin1','FindL1ObjIdx_setBx(L1EG_eta, L1EG_phi, L1EG_bx, probe_Eta, probe_Phi, -1, L1EG_hwIso, {})'.format(config['Isos'][iso]))
+        df_eg[i] = df_eg[i].Define('probe_idxL1EG_Bxplus1','FindL1ObjIdx_setBx(L1EG_eta, L1EG_phi, L1EG_bx, probe_Eta, probe_Phi, 1, L1EG_hwIso, {})'.format(config['Isos'][iso]))
 
         df_eg[i] = df_eg[i].Define('probe_L1Pt','GetVal(probe_idxL1EG, L1EG_pt)')
         df_eg[i] = df_eg[i].Define('probe_L1Bx','GetVal(probe_idxL1EG, L1EG_bx)')

--- a/helpers/helper_nano.py
+++ b/helpers/helper_nano.py
@@ -289,10 +289,10 @@ def DiJetSelection(df):
     '''
 
     df = df.Filter('HLT_AK8PFJet500&&PuppiMET_pt<300')
-    df = df.Define('isHighPtJet','Jet_jetId>=6&&Jet_pt>500&&Jet_muEF<0.5&&Jet_chEmEF<0.5')
-
-    df = df.Filter('Sum(isHighPtJet)>=2','>=2 jets with pt>500 GeV')
+    df = df.Define('isHighPtJet','Jet_jetId>=6&&Jet_pt>500&&Jet_muEF<0.5&&Jet_chEmEF<0.5&&Jet_neEmEF<0.8')
     
+    df = df.Filter('Sum(isHighPtJet)==2','=2 jets with pt>500 GeV')
+    df = df.Filter('isHighPtJet[0]&&isHighPtJet[1]','First 2 jets are the cleaned jets')
     df = df.Define('highPtJet_Pt','Jet_pt[isHighPtJet]')
     df = df.Define('highPtJet_Eta','Jet_eta[isHighPtJet]')
     df = df.Define('highPtJet_Phi','Jet_phi[isHighPtJet]')
@@ -301,7 +301,10 @@ def DiJetSelection(df):
     df = df.Define('_mjj', 'mll(Jet_pt, Jet_eta, Jet_phi, isHighPtJet, isHighPtJet)')
     df = df.Filter('_mjj>1000')
 
-
+    df = df.Define('barrelbarrel','abs(highPtJet_Eta[0])<1.3&&abs(highPtJet_Eta[1])<1.3')
+    df = df.Define('endcapendcap','abs(highPtJet_Eta[0])>1.3&&abs(highPtJet_Eta[1])>1.3')
+    
+    
     return df
 
 
@@ -843,6 +846,17 @@ def AnalyzeCleanJets(df, JetRecoPtCut, L1JetPtCut, suffix = ''):
 
 
 
+
+    return df, histos
+
+
+    
+def PrefiringVsMjj(df): 
+    histos = {}
+    histos['mjj_unpref_barrelbarrel'] =  df.Filter('(L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain)').Filter('barrelbarrel').Histo1D(ROOT.RDF.TH1DModel('mjj_unpref_barrelbarrel', '', len(ht_bins)-1, array('d',ht_bins) ), '_mjj')
+    histos['mjj_unpref_L1FinalORBXmin1_barrelbarrel'] =  df.Filter('L1_FinalOR_BXmin1').Filter('(L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain)').Filter('barrelbarrel').Histo1D(ROOT.RDF.TH1DModel('mjj_unpref_L1FinalORBXmin1_barrelbarrel', '', len(ht_bins)-1, array('d',ht_bins) ), '_mjj')
+    histos['mjj_unpref_endcapendcap'] =  df.Filter('(L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain)').Filter('endcapendcap').Histo1D(ROOT.RDF.TH1DModel('mjj_unpref_endcapendcap', '', len(ht_bins)-1, array('d',ht_bins) ), '_mjj')
+    histos['mjj_unpref_L1FinalORBXmin1_endcapendcap'] =  df.Filter('L1_FinalOR_BXmin1').Filter('(L1_UnprefireableEvent_TriggerRules||L1_UnprefireableEvent_FirstBxInTrain)').Filter('endcapendcap').Histo1D(ROOT.RDF.TH1DModel('mjj_unpref_L1FinalORBXmin1_endcapendcap', '', len(ht_bins)-1, array('d',ht_bins) ), '_mjj')
 
     return df, histos
 

--- a/l1macros/performances.py
+++ b/l1macros/performances.py
@@ -29,8 +29,9 @@ def main():
     parser.add_argument("-o", "--output", dest="outputFile", help="Output file", type=str, default='')
     parser.add_argument("-c", "--channel", dest="channel", help=
                         '''Set channel and analysis:
-                        -PhotonJet: For L1 jet studies with events trigger with a SinglePhoton trigger
-                        -MuonJet: For L1 jet studies with events trigger with a SingleMuon trigger
+                        -PhotonJet: For L1 jet studies with events triggered with a SinglePhoton trigger
+                        -DiJet: For L1 jet studies with events triggered with a SingleJet trigger
+                        -MuonJet: For L1 jet studies with events triggered with a SingleMuon trigger
                         -ZToMuMu: For L1 muon studies with Z->mumu
                         -ZToEE: For L1 EG studies with Z->ee''', 
                         type=str, default='PhotonJet')
@@ -44,6 +45,8 @@ def main():
     if inputFile == '':
         if args.channel == 'PhotonJet':
             inputFile = '/user/lathomas/Public/L1Studies/PhotonJet.root'
+        elif args.channel == 'DiJet':
+            inputFile = '/user/lathomas/Public/L1Studies/DiJet.root'
         elif args.channel == 'MuonJet':
             inputFile = '/user/lathomas/Public/L1Studies/MuJet.root'
         elif args.channel == 'ZToMuMu':
@@ -150,7 +153,7 @@ def main():
 #        
 #        df, histos_balance = AnalyzePtBalance(df)
 #        
-#        df_report = df.Report()
+        df_report = df.Report()
 #        
 #        df, histos_hf = HFNoiseStudy(df)
 #
@@ -164,7 +167,7 @@ def main():
 #            
 #        for i in histos_hf:
 #            histos_hf[i].GetValue().Write()
-#        df_report.Print()
+        df_report.Print()
         
         
     if args.channel == 'MuonJet':

--- a/l1macros/performances_nano.py
+++ b/l1macros/performances_nano.py
@@ -303,12 +303,14 @@ def main():
         all_histos_jets = {}
 
         df, histos_jets = h.AnalyzeCleanJets(df, 100, 50 )
-        #histos = {}
+        
+        df, histos_mjj = h.PrefiringVsMjj(df)
         
         for i in histos_jets:
             histos_jets[i].GetValue().Write()
 
-
+        for i in histos_mjj:
+            histos_mjj[i].GetValue().Write()
             
     nvtx_histo.GetValue().Write()
 

--- a/l1macros/performances_nano.py
+++ b/l1macros/performances_nano.py
@@ -31,6 +31,7 @@ def main():
     parser.add_argument("-c", "--channel", dest="channel", help=
                         '''Set channel and analysis:
                         -PhotonJet: For L1 jet studies with events trigger with a SinglePhoton trigger
+                        -DiJet: For L1 jet studies with events triggered with a SingleJet trigger
                         -MuonJet: For L1 jet studies with events trigger with a SingleMuon trigger
                         -ZToMuMu: For L1 muon studies with Z->mumu
                         -ZToEE: For L1 EG studies with Z->ee''', 
@@ -44,18 +45,16 @@ def main():
     inputFile = args.inputFile
     if inputFile == '':
         if args.channel == 'PhotonJet':
-            #inputFile = '/user/lathomas/Public/L1Studies/PhotonJet.root'
-            inputFile = '/pnfs/iihe/cms/ph/sc4/store/data/Run2023C/EGamma0/NANOAOD/PromptNanoAODv11p9_v1-v1/70000/3b1e99a5-71a0-46ee-b720-b79669f60029.root'
+            inputFile = '/pnfs/iihe/cms/store/user/lathomas/EGamma1/2023Dv1_L1TNanowithPrefiringInfo/231129_154543/0000/out_234.root'
         elif args.channel == 'MuonJet':
-            #inputFile = '/user/lathomas/Public/L1Studies/MuJet.root'
-            inputFile = '/pnfs/iihe/cms/ph/sc4/store/data/Run2023C/Muon1/NANOAOD/PromptNanoAODv11p9_v1-v1/60000/37c190ac-242c-47d7-a98f-9c51b111ff00.root'
+            inputFile = '/pnfs/iihe/cms/store/user/lathomas/Muon1/2023Dv1_L1TNanowithPrefiringInfo/231129_162737/0000/out_196.root'
         elif args.channel == 'ZToMuMu':
-            #inputFile = '/user/lathomas/Public/L1Studies/ZToMuMu.root'
-            inputFile = '/pnfs/iihe/cms/ph/sc4/store/data/Run2023C/Muon1/NANOAOD/PromptNanoAODv11p9_v1-v1/60000/37c190ac-242c-47d7-a98f-9c51b111ff00.root'
+            inputFile = '/pnfs/iihe/cms/store/user/lathomas/Muon1/2023Dv1_L1TNanowithPrefiringInfo/231129_162737/0000/out_196.root'
         elif args.channel == 'ZToEE':
-            #inputFile = '/user/lathomas/Public/L1Studies/ZToEE.root'
-            inputFile = '/pnfs/iihe/cms/ph/sc4/store/data/Run2023C/EGamma0/NANOAOD/PromptNanoAODv11p9_v1-v1/70000/3b1e99a5-71a0-46ee-b720-b79669f60029.root'
-
+            inputFile = '/pnfs/iihe/cms/store/user/lathomas/EGamma1/2023Dv1_L1TNanowithPrefiringInfo/231129_154543/0000/out_234.root'
+        elif args.channel == 'DiJet':
+            inputFile = '/pnfs/iihe/cms/store/user/lathomas/JetMET1/2023Dv1_L1TNanowithPrefiringInfo/231129_162802/0000/out_98.root'
+        
     ### Set default config file
     config_file = args.config
     if config_file == '':
@@ -67,6 +66,8 @@ def main():
             config_file = '../config_cards/full_ZToMuMu.yaml'
         elif args.channel == 'ZToEE':
             config_file = '../config_cards/full_ZToEE.yaml'
+        if args.channel == 'DiJet':
+            config_file = '../config_cards/full_DiJet.yaml'
 
     # Read config and set config_dict in helper
     with open(config_file) as s:
@@ -113,13 +114,13 @@ def main():
     out = ROOT.TFile(args.outputFile, "recreate")
     ####The sequence of filters/column definition starts here
     
-    if args.channel not in ['PhotonJet','MuonJet','ZToMuMu','ZToEE']:
+    if args.channel not in ['PhotonJet','MuonJet','ZToMuMu','ZToEE', 'DiJet']:
         print("Channel {} does not exist".format(args.channel))
         return 
 
     # add nvtx histo
     nvtx_histo = df.Histo1D(ROOT.RDF.TH1DModel("h_nvtx" , "Number of reco vertices;N_{vtx};Events"  ,    100, 0., 100.), "PV_npvs")
-    nvtx_histo.GetValue().Write()
+
         
     if args.channel == 'PhotonJet':
         df = h.SinglePhotonSelection(df) 
@@ -286,6 +287,22 @@ def main():
 
         for i in all_histos:
             all_histos[i].GetValue().Write()
+
+    if args.channel == 'DiJet':
+        df = h.DiJetSelection(df) 
+        #df = h.DiJet_Plots(df)
+        df = h.CleanJets(df)
+        all_histos_jets = {}
+
+        df, histos_jets = h.AnalyzeCleanJets(df, 100, 50 )
+        #histos = {}
+        
+        for i in histos_jets:
+            histos_jets[i].GetValue().Write()
+
+
+            
+    nvtx_histo.GetValue().Write()
 
 if __name__ == '__main__':
     main()

--- a/l1macros/performances_nano.py
+++ b/l1macros/performances_nano.py
@@ -95,7 +95,15 @@ def main():
         df = df.Filter(fltr)
     nEvents = df.Count().GetValue()
 
+    if not 'L1_UnprefireableEvent_TriggerRules' in df.GetColumnNames():
+        df = df.Define('L1_UnprefireableEvent_TriggerRules','L1_UnprefireableEvent')
+    if not 'L1_UnprefireableEvent_FirstBxInTrain' in df.GetColumnNames():
+        df = df.Define('L1_UnprefireableEvent_FirstBxInTrain','return false;')
+    
+
     print('There are {} events'.format(nEvents))
+
+    
 
     #Max events to run on 
     max_events = min(nEvents, args.max_events) if args.max_events >=0 else nEvents


### PR DESCRIPTION
This PR updates/adds several monitoring plots for prefiring. A new channel (`DiJet`) is also created, targeting high mass dijet pairs. 
The NANO version of the code is now set up to run on future NANOAOD re-reco, produced with future CMSSW releases that will include the following PR: https://github.com/cms-sw/cmssw/pull/43387 
It will crash with current NANOAOD however due to missing prefiring information added by that PR. 
Privately produced NANOAOD samples with the available information are however available and can be used for tests.

@hugues-evard can you take a look and let me know if you have any comment? (focusing on the NANO version of the code, since the non NANO version will likely soon be useless). 

Thanks. 
